### PR TITLE
Handle empty dnsSearchDomains

### DIFF
--- a/pkg/openstackbaremetalset/baremetalhost.go
+++ b/pkg/openstackbaremetalset/baremetalhost.go
@@ -111,6 +111,8 @@ func BaremetalHostProvision(
 
 		if len(instance.Spec.DNSSearchDomains) > 0 {
 			templateParameters["CtlplaneDnsSearch"] = instance.Spec.DNSSearchDomains
+		} else {
+			templateParameters["CtlplaneDnsSearch"] = []string{}
 		}
 
 		networkDataSecretName := fmt.Sprintf(CloudInitNetworkDataSecretName, instance.Name, bmh)


### PR DESCRIPTION
When generating the default networkdata, handle empty vlaue, else it fails with "<len .CtlplaneDnsSearch>: error calling len: reflect: call of reflect.Value.Type on zero Value"}"