### PR TITLE
Controller manager label finalization

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    control-plane: baremetal-controller-manager
+    control-plane: controller-manager
     app.kubernetes.io/name: namespace
     app.kubernetes.io/instance: system
     app.kubernetes.io/component: manager
@@ -17,24 +17,26 @@ metadata:
   name: controller-manager
   namespace: system
   labels:
-    control-plane: baremetal-controller-manager
+    control-plane: controller-manager
     app.kubernetes.io/name: deployment
     app.kubernetes.io/instance: controller-manager
     app.kubernetes.io/component: manager
     app.kubernetes.io/created-by: openstack-baremetal-operator
     app.kubernetes.io/part-of: openstack-baremetal-operator
     app.kubernetes.io/managed-by: kustomize
+    openstack.org/operator-name: baremetal
 spec:
   selector:
     matchLabels:
-      control-plane: baremetal-controller-manager
+      openstack.org/operator-name: baremetal
   replicas: 1
   template:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        control-plane: baremetal-controller-manager
+        control-plane: controller-manager
+        openstack.org/operator-name: baremetal
     spec:
       # TODO(user): Uncomment the following code to configure the nodeAffinity expression
       # according to the platforms which are supported by your solution.

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -4,7 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    control-plane: baremetal-controller-manager
+    control-plane: controller-manager
     app.kubernetes.io/name: servicemonitor
     app.kubernetes.io/instance: controller-manager-metrics-monitor
     app.kubernetes.io/component: metrics
@@ -23,4 +23,4 @@ spec:
         insecureSkipVerify: true
   selector:
     matchLabels:
-      control-plane: baremetal-controller-manager
+      openstack.org/operator-name: baremetal

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    control-plane: baremetal-controller-manager
+    control-plane: controller-manager
     app.kubernetes.io/name: service
     app.kubernetes.io/instance: controller-manager-metrics-service
     app.kubernetes.io/component: kube-rbac-proxy
@@ -18,4 +18,4 @@ spec:
     protocol: TCP
     targetPort: https
   selector:
-    control-plane: baremetal-controller-manager
+    openstack.org/operator-name: baremetal

--- a/config/webhook/service.yaml
+++ b/config/webhook/service.yaml
@@ -17,4 +17,4 @@ spec:
       protocol: TCP
       targetPort: 9443
   selector:
-    control-plane: baremetal-controller-manager
+    openstack.org/operator-name: baremetal


### PR DESCRIPTION
We now have a final form for operator controller-manager pod labeling of the format `openstack.org/operator-name: <operator name>` and are no longer relying on the inconsistent labels created by various `operator-sdk` versions.  All operators that lack this standardized pattern are being updated.