### PR TITLE
Allow user provided provisioning interface

### DIFF
--- a/api/bases/baremetal.openstack.org_openstackbaremetalsets.yaml
+++ b/api/bases/baremetal.openstack.org_openstackbaremetalsets.yaml
@@ -264,6 +264,10 @@ spec:
                 description: ProvisionServerName - Optional. If supplied will be used
                   as the base Image for the baremetalset instead of baseImageURL.
                 type: string
+              provisioningInterface:
+                description: ProvisioningInterface - Optional. If not provided along
+                  with ProvisionServerName, it would be discovered from CBO.
+                type: string
               rhelImageUrl:
                 description: RhelImageURL - Remote URL pointing to desired RHEL qcow2
                   image

--- a/api/v1beta1/openstackbaremetalset_types.go
+++ b/api/v1beta1/openstackbaremetalset_types.go
@@ -71,6 +71,8 @@ type OpenStackBaremetalSetSpec struct {
 	AutomatedCleaningMode AutomatedCleaningMode `json:"automatedCleaningMode,omitempty"`
 	// ProvisionServerName - Optional. If supplied will be used as the base Image for the baremetalset instead of baseImageURL.
 	ProvisionServerName string `json:"provisionServerName,omitempty"`
+	// ProvisioningInterface - Optional. If not provided along with ProvisionServerName, it would be discovered from CBO.
+	ProvisioningInterface string `json:"provisioningInterface,omitempty"`
 	// DeploymentSSHSecret - Name of secret holding the stack-admin ssh keys
 	DeploymentSSHSecret string `json:"deploymentSSHSecret"`
 	// CtlplaneInterface - Interface to use for ctlplane network

--- a/config/crd/bases/baremetal.openstack.org_openstackbaremetalsets.yaml
+++ b/config/crd/bases/baremetal.openstack.org_openstackbaremetalsets.yaml
@@ -264,6 +264,10 @@ spec:
                 description: ProvisionServerName - Optional. If supplied will be used
                   as the base Image for the baremetalset instead of baseImageURL.
                 type: string
+              provisioningInterface:
+                description: ProvisioningInterface - Optional. If not provided along
+                  with ProvisionServerName, it would be discovered from CBO.
+                type: string
               rhelImageUrl:
                 description: RhelImageURL - Remote URL pointing to desired RHEL qcow2
                   image

--- a/controllers/openstackbaremetalset_controller.go
+++ b/controllers/openstackbaremetalset_controller.go
@@ -303,7 +303,7 @@ func (r *OpenStackBaremetalSetReconciler) reconcileNormal(ctx context.Context, i
 	//
 
 	serviceLabels := labels.GetLabels(instance, openstackprovisionserver.AppLabel, map[string]string{
-		common.AppSelector: instance.Name + "-openstackbaremetalset-deployment",
+		common.AppSelector: instance.Name + "-deployment",
 	})
 
 	// Handle service init
@@ -485,6 +485,7 @@ func (r *OpenStackBaremetalSetReconciler) provisionServerCreateOrUpdate(
 		}
 
 		provisionServer.Spec.RhelImageURL = instance.Spec.RhelImageURL
+		provisionServer.Spec.Interface = instance.Spec.ProvisioningInterface
 
 		err = controllerutil.SetControllerReference(instance, provisionServer, helper.GetScheme())
 		if err != nil {

--- a/controllers/openstackprovisionserver_controller.go
+++ b/controllers/openstackprovisionserver_controller.go
@@ -270,7 +270,7 @@ func (r *OpenStackProvisionServerReconciler) reconcileNormal(ctx context.Context
 	instance.Status.Conditions.MarkTrue(baremetalv1.OpenStackProvisionServerProvIntfReadyCondition, baremetalv1.OpenStackProvisionServerProvIntfReadyMessage)
 
 	serviceLabels := labels.GetLabels(instance, openstackprovisionserver.AppLabel, map[string]string{
-		common.AppSelector: instance.Name + "-openstackprovisionserver-deployment",
+		common.AppSelector: instance.Name + "-deployment",
 	})
 
 	// Handle service init


### PR DESCRIPTION
The current logic when provisionserver is not provided is to create a provisionserver. It looks for CBO kind provisionings.metal3.io which does not exist when not using CBO.

Also caters for labels going beyond 63 chars.

"spec.selector.matchLabels: Invalid value:
edpm-compute-provisionserver-openstackprovisionserver-deployment: must be no more than 63 characters"