### PR TITLE
Add edpm baremetal CI job

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -1,0 +1,14 @@
+---
+- job:
+    name: openstack-baremetal-operator-content-provider
+    parent: content-provider-base
+    vars:
+      cifmw_operator_build_org: openstack-k8s-operators
+      cifmw_operator_build_operators:
+        - name: "openstack-operator"
+          src: "~/src/github.com/{{ cifmw_operator_build_org }}/openstack-operator"
+          image_base: openstack-baremetal
+
+- job:
+    name: openstack-baremetal-operator-crc-podified-edpm-baremetal
+    parent: cifmw-crc-podified-edpm-baremetal

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -1,0 +1,9 @@
+---
+- project:
+    name: openstack-k8s-operators/openstack-baremetal-operator
+    github-check:
+      jobs:
+        - openstack-baremetal-operator-content-provider
+        - openstack-baremetal-operator-crc-podified-edpm-baremetal:
+            dependencies:
+              - openstack-baremetal-operator-content-provider


### PR DESCRIPTION
It adds the following jobs which will run against openstack baremetal operator.
- openstack-baremetal-operator-content-provider job which will build the operator
  and meta operator images and push it to local registry. The job will
  be paused to serve as a registry.
- openstack-baremetal-operator-crc-podified-edpm-deployment is the child job which
  will pull the required meta operator images from content provider.
  The Zuul will pass the necessary vars to the child job.

