### PR TITLE
Drop webhook validation for OSImage

### DIFF
--- a/api/v1beta1/openstackbaremetalset_webhook.go
+++ b/api/v1beta1/openstackbaremetalset_webhook.go
@@ -78,7 +78,7 @@ func (r *OpenStackBaremetalSet) ValidateCreate() error {
 		return err
 	}
 
-	return r.validateCr()
+	return nil
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
@@ -149,30 +149,13 @@ func (r *OpenStackBaremetalSet) ValidateUpdate(old runtime.Object) error {
 		}
 	}
 
-	return r.validateCr()
+	return nil
 
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type
 func (r *OpenStackBaremetalSet) ValidateDelete() error {
 	openstackbaremetalsetlog.Info("validate delete", "name", r.Name)
-
-	return nil
-}
-
-func (r *OpenStackBaremetalSet) validateCr() error {
-	if err := r.checkBaseImageReqs(); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (r *OpenStackBaremetalSet) checkBaseImageReqs() error {
-	// TODO(rabi): Uncomment after dataplane-operator api bump
-	// if r.Spec.OSImage == "" && r.Spec.ProvisionServerName == "" {
-	//	 return fmt.Errorf("either \"osImage\" or \"provisionServerName\" must be provided")
-	// }
 
 	return nil
 }


### PR DESCRIPTION
Both OSImage and ProvisionServerName are optional and they work as below.

1. Existing ProvisionServer used if ProvisionServerName in spec
2. Else, if OSImage in spec it would be used, but it should be available locally in the init container running with OSContainerImageURL.
3. If none of them are there in the spec, OS_IMAGE_DEFAULT in OS_CONTAINER_IMAGE_URL_DEFAULT would be used. Both can be patched in csv ENV or their defaults would be used.