### PR TITLE
Clarifying comments for OSBMS interface fields

### DIFF
--- a/api/bases/baremetal.openstack.org_openstackbaremetalsets.yaml
+++ b/api/bases/baremetal.openstack.org_openstackbaremetalsets.yaml
@@ -121,7 +121,8 @@ spec:
                   (TODO: acquire this is another manner?)'
                 type: string
               ctlplaneInterface:
-                description: CtlplaneInterface - Interface to use for ctlplane network
+                description: CtlplaneInterface - Interface on the provisioned nodes
+                  to use for ctlplane network
                 type: string
               ctlplaneNetmask:
                 default: 255.255.255.0
@@ -270,7 +271,8 @@ spec:
                 type: string
               provisioningInterface:
                 description: ProvisioningInterface - Optional. If not provided along
-                  with ProvisionServerName, it would be discovered from CBO.
+                  with ProvisionServerName, it would be discovered from CBO.  This
+                  is the provisioning interface on the OCP masters/workers.
                 type: string
               userData:
                 description: UserData holds the reference to the Secret containing

--- a/api/v1beta1/openstackbaremetalset_types.go
+++ b/api/v1beta1/openstackbaremetalset_types.go
@@ -73,12 +73,12 @@ type OpenStackBaremetalSetSpec struct {
 	// ProvisionServerName - Optional. If supplied will be used as the base Image for the baremetalset instead of baseImageURL.
 	// +kubebuilder:validation:Optional
 	ProvisionServerName string `json:"provisionServerName,omitempty"`
-	// ProvisioningInterface - Optional. If not provided along with ProvisionServerName, it would be discovered from CBO.
+	// ProvisioningInterface - Optional. If not provided along with ProvisionServerName, it would be discovered from CBO.  This is the provisioning interface on the OCP masters/workers.
 	// +kubebuilder:validation:Optional
 	ProvisioningInterface string `json:"provisioningInterface,omitempty"`
 	// DeploymentSSHSecret - Name of secret holding the cloud-admin ssh keys
 	DeploymentSSHSecret string `json:"deploymentSSHSecret"`
-	// CtlplaneInterface - Interface to use for ctlplane network
+	// CtlplaneInterface - Interface on the provisioned nodes to use for ctlplane network
 	CtlplaneInterface string `json:"ctlplaneInterface"`
 	// CtlplaneGateway - IP of gateway for ctrlplane network (TODO: acquire this is another manner?)
 	// +kubebuilder:validation:Optional

--- a/config/crd/bases/baremetal.openstack.org_openstackbaremetalsets.yaml
+++ b/config/crd/bases/baremetal.openstack.org_openstackbaremetalsets.yaml
@@ -121,7 +121,8 @@ spec:
                   (TODO: acquire this is another manner?)'
                 type: string
               ctlplaneInterface:
-                description: CtlplaneInterface - Interface to use for ctlplane network
+                description: CtlplaneInterface - Interface on the provisioned nodes
+                  to use for ctlplane network
                 type: string
               ctlplaneNetmask:
                 default: 255.255.255.0
@@ -270,7 +271,8 @@ spec:
                 type: string
               provisioningInterface:
                 description: ProvisioningInterface - Optional. If not provided along
-                  with ProvisionServerName, it would be discovered from CBO.
+                  with ProvisionServerName, it would be discovered from CBO.  This
+                  is the provisioning interface on the OCP masters/workers.
                 type: string
               userData:
                 description: UserData holds the reference to the Secret containing


### PR DESCRIPTION
Just wanted to add some comments to `CtlPlaneInterface` and `ProvisioningInterface` fields in the `OSBMS` to better distinguish them from one another and clarify their purposes.