### PR TITLE
Configure renovate to pin k8s and controller-runtime for dev preview

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,29 +20,25 @@
         {
           "groupName": "openstack-k8s-operators",
           "matchPackagePrefixes": ["github.com/openstack-k8s-operators"],
-          "excludePackageNames": ["github.com/openstack-k8s-operators/openstack-baremetal-operator/api"],
-          "schedule": [
-            "every weekend"
-          ]
+          "excludePackageNames": ["github.com/openstack-k8s-operators/openstack-baremetal-operator/api"]
         },
         {
           "groupName": "k8s.io",
-          "matchPackagePrefixes": [
-            "k8s.io",
-            "sigs.k8s.io"
-          ],
-          "schedule": [
-            "every weekend"
-          ],
-          "allowedVersions": "< 1.0.0"
+          "matchPackagePatterns": ["^k8s.io"],
+          "excludePackagePatterns": ["^k8s.io/kube-openapi"],
+          "allowedVersions": "< 0.27.0",
+          "enabled": true
+        },
+        {
+          "groupName": "sigs.k8s.io/controller-runtime",
+          "matchPackagePatterns": ["^sigs.k8s.io/controller-runtime"],
+          "allowedVersions": "< 0.15.0",
+          "enabled": true
         },
         {
           "groupName": "metal3.io",
           "matchPackagePrefixes": [
             "github.com/metal3-io"
-          ],
-          "schedule": [
-            "every weekend"
           ],
           "allowedVersions": "< 1.0.0"
         }


### PR DESCRIPTION
This pins k8s and controller runtime to be in sync with lib-common and configure renovate to keep the pin