### PR TITLE
Remove leader election for controller

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -52,4 +52,3 @@ spec:
         args:
         - "--health-probe-bind-address=:8081"
         - "--metrics-bind-address=127.0.0.1:8080"
-        - "--leader-elect"

--- a/config/manager/controller_manager_config.yaml
+++ b/config/manager/controller_manager_config.yaml
@@ -7,5 +7,5 @@ metrics:
 webhook:
   port: 9443
 leaderElection:
-  leaderElect: true
+  leaderElect: false
   resourceName: c569355b.openstack.org

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -70,8 +70,6 @@ spec:
       containers:
       - command:
         - /manager
-        args:
-        - --leader-elect
         image: controller:latest
         name: manager
         securityContext:


### PR DESCRIPTION
As we're running a single replica for the controller manager we probably don't need leader election. If we configure more replicas in the future maybe we could use an ENV var.