### PR TITLE
Do not update spec by controller

### DIFF
--- a/api/bases/baremetal.openstack.org_openstackprovisionservers.yaml
+++ b/api/bases/baremetal.openstack.org_openstackprovisionservers.yaml
@@ -194,6 +194,10 @@ spec:
               localImageUrl:
                 description: URL of provisioning image on underlying Apache web server
                 type: string
+              port:
+                description: Port - The port on which the Apache server should listen
+                format: int32
+                type: integer
               provisionIp:
                 description: IP of the provisioning interface on the node running
                   the ProvisionServer pod

--- a/api/v1beta1/openstackprovisionserver.go
+++ b/api/v1beta1/openstackprovisionserver.go
@@ -27,7 +27,7 @@ func GetExistingProvServerPorts(
 	}
 
 	for _, provServer := range provServerList.Items {
-		found[provServer.Name] = provServer.Spec.Port
+		found[provServer.Name] = provServer.Status.Port
 	}
 
 	return found, nil
@@ -40,7 +40,7 @@ func AssignProvisionServerPort(
 	instance *OpenStackProvisionServer,
 	portStart int32,
 ) error {
-	if instance.Spec.Port != 0 {
+	if instance.Status.Port != 0 {
 		// Do nothing, already assigned
 		return nil
 	}
@@ -52,10 +52,10 @@ func AssignProvisionServerPort(
 
 	// It's possible that this prov server already exists and we are just dealing with
 	// a minimized version of it (only its ObjectMeta is set, etc)
-	instance.Spec.Port = existingPorts[instance.GetName()]
+	instance.Status.Port = existingPorts[instance.GetName()]
 
 	// If we get this far, no port has been previously assigned, so we pick one
-	if instance.Spec.Port == 0 {
+	if instance.Status.Port == 0 {
 		cur := portStart
 
 		for {
@@ -75,7 +75,7 @@ func AssignProvisionServerPort(
 			cur++
 		}
 
-		instance.Spec.Port = cur
+		instance.Status.Port = cur
 	}
 
 	return nil

--- a/api/v1beta1/openstackprovisionserver_types.go
+++ b/api/v1beta1/openstackprovisionserver_types.go
@@ -70,6 +70,8 @@ type OpenStackProvisionServerStatus struct {
 	Conditions condition.Conditions `json:"conditions,omitempty" optional:"true"`
 	// Map of hashes to track e.g. job status
 	Hash map[string]string `json:"hash,omitempty"`
+	// Port - The port on which the Apache server should listen
+	Port int32 `json:"port,omitempty"`
 	// IP of the provisioning interface on the node running the ProvisionServer pod
 	ProvisionIP string `json:"provisionIp,omitempty"`
 	// URL of provisioning image on underlying Apache web server

--- a/config/crd/bases/baremetal.openstack.org_openstackprovisionservers.yaml
+++ b/config/crd/bases/baremetal.openstack.org_openstackprovisionservers.yaml
@@ -194,6 +194,10 @@ spec:
               localImageUrl:
                 description: URL of provisioning image on underlying Apache web server
                 type: string
+              port:
+                description: Port - The port on which the Apache server should listen
+                format: int32
+                type: integer
               provisionIp:
                 description: IP of the provisioning interface on the node running
                   the ProvisionServer pod

--- a/controllers/openstackprovisionserver_controller.go
+++ b/controllers/openstackprovisionserver_controller.go
@@ -188,6 +188,9 @@ func (r *OpenStackProvisionServerReconciler) Reconcile(ctx context.Context, req 
 	if instance.Status.Hash == nil {
 		instance.Status.Hash = map[string]string{}
 	}
+	if instance.Status.Port != instance.Spec.Port {
+		instance.Status.Port = instance.Spec.Port
+	}
 
 	// Handle service delete
 	if !instance.DeletionTimestamp.IsZero() {
@@ -460,7 +463,7 @@ func (r *OpenStackProvisionServerReconciler) generateServiceConfigMaps(
 	cmLabels := labels.GetLabels(instance, openstackprovisionserver.AppLabel, map[string]string{})
 
 	templateParameters := make(map[string]interface{})
-	templateParameters["Port"] = strconv.FormatInt(int64(instance.Spec.Port), 10)
+	templateParameters["Port"] = strconv.FormatInt(int64(instance.Status.Port), 10)
 
 	cms := []util.Template{
 		// Apache server config
@@ -574,5 +577,5 @@ func (r *OpenStackProvisionServerReconciler) getProvisioningInterface(
 
 func (r *OpenStackProvisionServerReconciler) getLocalImageURL(instance *baremetalv1.OpenStackProvisionServer) string {
 	baseFilename := instance.Spec.OSImage
-	return fmt.Sprintf("http://%s:%d/%s", instance.Status.ProvisionIP, instance.Spec.Port, baseFilename)
+	return fmt.Sprintf("http://%s:%d/%s", instance.Status.ProvisionIP, instance.Status.Port, baseFilename)
 }


### PR DESCRIPTION
As described in the Kubernetes API conventions, Kubernetes controllers should avoid updating user owned object Spec sections:

https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status

This updates the controller logic to use instance.Status.Port instead of modifying instance.Spec.Port.