### PR TITLE
Support disconnected network environments

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: tools
   namespace: openstack-k8s-operators
-  tag: ci-build-root-golang-1.19-sdk-1.26
+  tag: ci-build-root-golang-1.19-sdk-1.31

--- a/.github/create_bundle.sh
+++ b/.github/create_bundle.sh
@@ -1,63 +1,13 @@
 #!/bin/bash
 set -e
 
-CLUSTER_BUNDLE_FILE="bundle/manifests/openstack-baremetal-operator.clusterserviceversion.yaml"
-
-echo "Creating openstack baremetal operator bundle"
+echo "Creating openstack-baremetal-operator bundle"
 cd ..
 echo "${GITHUB_SHA}"
 echo "${BASE_IMAGE}"
-skopeo --version
-
-echo "Calculating image digest for docker://${REGISTRY}/${BASE_IMAGE}:${GITHUB_SHA}"
-DIGEST=$(skopeo inspect docker://${REGISTRY}/${BASE_IMAGE}:${GITHUB_SHA} | jq '.Digest' -r)
-# Output:
-# Calculating image digest for docker://quay.io/openstack-k8s-operators/openstack-baremetal-operator:d03f2c1c362c04fc5ef819f92a218f9ea59bbd0c
-# Digest: sha256:1d5b578fd212f8dbd03c0235f1913ef738721766f8c94236af5efecc6d8d8cb1
-echo "Digest: ${DIGEST}"
 
 RELEASE_VERSION=$(grep "^VERSION" Makefile | awk -F'?= ' '{ print $2 }')
-OPERATOR_IMG_WITH_DIGEST="${REGISTRY}/${BASE_IMAGE}@${DIGEST}"
-
-echo "New Operator Image with Digest: $OPERATOR_IMG_WITH_DIGEST"
 echo "Release Version: $RELEASE_VERSION"
 
 echo "Creating bundle image..."
-VERSION=$RELEASE_VERSION IMG=$OPERATOR_IMG_WITH_DIGEST make bundle
-
-echo "Bundle file images:"
-cat "${CLUSTER_BUNDLE_FILE}" | grep "image:"
-# FIXME: display any ENV variables once we have offline support implemented
-#grep -A1 IMAGE_URL_DEFAULT "${CLUSTER_BUNDLE_FILE}"
-
-# We do not want to exit here. Some images are in different registries, so
-# error will be reported to the console.
-set +e
-for csv_image in $(cat "${CLUSTER_BUNDLE_FILE}" | grep "image:" | sed -e "s|.*image:||" | sort -u); do
-    digest_image=""
-    echo "CSV line: ${csv_image}"
-
-    # case where @ is in the csv_image image
-    if [[ "$csv_image" =~ .*"@".* ]]; then
-        delimeter='@'
-    else
-        delimeter=':'
-    fi
-
-    base_image=$(echo $csv_image | cut -f 1 -d${delimeter})
-    tag_image=$(echo $csv_image | cut -f 2 -d${delimeter})
-    digest_image=$(skopeo inspect docker://${base_image}${delimeter}${tag_image} | jq '.Digest' -r)
-    echo "Base image: $base_image"
-    if [ -n "$digest_image" ]; then
-        echo "$base_image${delimeter}$tag_image becomes $base_image@$digest_image"
-        sed -i "s|$base_image$delimeter$tag_image|$base_image@$digest_image|g" "${CLUSTER_BUNDLE_FILE}"
-    else
-        echo "$base_image${delimeter}$tag_image not changed"
-    fi
-done
-
-echo "Resulting bundle file images:"
-cat "${CLUSTER_BUNDLE_FILE}" | grep "image:"
-
-# FIXME: display any ENV variables once we have offline support implemented
-#grep -A1 IMAGE_URL_DEFAULT "${CLUSTER_BUNDLE_FILE}"
+USE_IMAGE_DIGESTS=true VERSION=$RELEASE_VERSION IMG=${REGISTRY}/${BASE_IMAGE}:${GITHUB_SHA} make bundle

--- a/.github/workflows/build-openstack-baremetal-operator.yaml
+++ b/.github/workflows/build-openstack-baremetal-operator.yaml
@@ -91,7 +91,7 @@ jobs:
       uses: redhat-actions/openshift-tools-installer@v1
       with:
         source: github
-        operator-sdk: '1.26.0'
+        operator-sdk: '1.31.0'
 
     - name: Log in to Quay Registry
       uses: redhat-actions/podman-login@v1

--- a/.prow_ci.env
+++ b/.prow_ci.env
@@ -1,0 +1,1 @@
+export USE_IMAGE_DIGESTS=true

--- a/api/v1beta1/openstackprovisionserver_types.go
+++ b/api/v1beta1/openstackprovisionserver_types.go
@@ -138,9 +138,9 @@ func (instance OpenStackProvisionServer) RbacResourceName() string {
 func SetupDefaults() {
 	// Acquire environmental defaults and initialize OpenStackProvisionServer defaults with them
 	openstackProvisionServerDefaults := OpenStackProvisionServerDefaults{
-		OSContainerImageURL: util.GetEnvVar("OS_CONTAINER_IMAGE_URL_DEFAULT", OSContainerImage),
-		AgentImageURL:       util.GetEnvVar("AGENT_IMAGE_URL_DEFAULT", AgentImage),
-		ApacheImageURL:      util.GetEnvVar("APACHE_IMAGE_URL_DEFAULT", ApacheImage),
+		OSContainerImageURL: util.GetEnvVar("RELATED_IMAGE_OS_CONTAINER_IMAGE_URL_DEFAULT", OSContainerImage),
+		AgentImageURL:       util.GetEnvVar("RELATED_IMAGE_AGENT_IMAGE_URL_DEFAULT", AgentImage),
+		ApacheImageURL:      util.GetEnvVar("RELATED_IMAGE_APACHE_IMAGE_URL_DEFAULT", ApacheImage),
 		OSImage:             util.GetEnvVar("OS_IMAGE_DEFAULT", OSImage),
 	}
 

--- a/config/default/manager_default_images.yaml
+++ b/config/default/manager_default_images.yaml
@@ -11,11 +11,11 @@ spec:
       containers:
       - name: manager
         env:
-        - name: OS_CONTAINER_IMAGE_URL_DEFAULT
+        - name: RELATED_IMAGE_OS_CONTAINER_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/edpm-hardened-uefi:current-podified
-        - name: AGENT_IMAGE_URL_DEFAULT
+        - name: RELATED_IMAGE_AGENT_IMAGE_URL_DEFAULT
           value: quay.io/openstack-k8s-operators/openstack-baremetal-operator-agent:latest
-        - name: APACHE_IMAGE_URL_DEFAULT
+        - name: RELATED_IMAGE_APACHE_IMAGE_URL_DEFAULT
           value: registry.redhat.io/rhel8/httpd-24:latest
         - name: OS_IMAGE_DEFAULT
           value: edpm-hardened-uefi.qcow2

--- a/config/manifests/bases/openstack-baremetal-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/openstack-baremetal-operator.clusterserviceversion.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
+    operators.openshift.io/infrastructure-features: '["disconnected"]'
     operators.operatorframework.io/operator-type: non-standalone
   name: openstack-baremetal-operator.v0.0.0
   namespace: placeholder

--- a/config/samples/baremetal_v1beta1_openstackprovisionserver.yaml
+++ b/config/samples/baremetal_v1beta1_openstackprovisionserver.yaml
@@ -3,9 +3,9 @@ kind: OpenStackProvisionServer
 metadata:
   name: openstackprovisionserver
 spec:
-  agentImageUrl: quay.io/openstack-k8s-operators/openstack-baremetal-operator-agent:v0.0.1
+  agentImageUrl: quay.io/openstack-k8s-operators/openstack-baremetal-operator-agent:latest
   apacheImageUrl: registry.redhat.io/rhel8/httpd-24:latest
-  downloaderImageUrl: quay.io/openstack-k8s-operators/openstack-baremetal-operator-downloader:v0.0.1
+  downloaderImageUrl: quay.io/openstack-k8s-operators/openstack-baremetal-operator-downloader:latest
   interface: enp1s0
   port: 8080
   osImage: edpm-hardened-uefi.qcow2


### PR DESCRIPTION
This PR adds support for installing the operator in disconnected network environments. To build with image-digests set USE_IMAGE_DIGESTS=true before running make bundle.

For Prow jobs we are enabling this via .prow-ci.env

This drops the old logic from create_bundle.sh which has been broken with operator-sdk's make bundle for some time.

Also, bumps to operator-sdk-1.31 since this operator has artifacts from registry.redhat.io that require auth to work to obtain the sha's

(NOTE: this currently requires a secure registry)

Jira: [OSP-26486](https://issues.redhat.com//browse/OSP-26486)