### PR TITLE
Login to registry.redhat.io for bundle builds

### DIFF
--- a/.github/workflows/build-openstack-baremetal-operator.yaml
+++ b/.github/workflows/build-openstack-baremetal-operator.yaml
@@ -100,6 +100,13 @@ jobs:
         username: ${{ secrets.QUAY_USERNAME }}
         password: ${{ secrets.QUAY_PASSWORD }}
 
+    - name: Log in to Red Hat Registry
+      uses: redhat-actions/podman-login@v1
+      with:
+        registry: ${{ env.imageregistry }}
+        username: ${{ secrets.REDHATIO_USERNAME }}
+        password: ${{ secrets.REDHATIO_PASSWORD }}
+
     - name: Create bundle image
       run: |
         pushd "${GITHUB_WORKSPACE}"/.github/
@@ -163,7 +170,7 @@ jobs:
         source: github
         opm: 'latest'
 
-    - name: Log in to Red Hat Registry
+    - name: Log in to Quay Registry
       uses: redhat-actions/podman-login@v1
       with:
         registry: ${{ env.imageregistry }}


### PR DESCRIPTION
Fix to allow the github workflow for bundles to login to the redhat registry. This is required in order to obtain the correct SHA265 info for containers used from there