### PR TITLE
Always build images

### DIFF
--- a/.github/workflows/build-openstack-baremetal-operator.yaml
+++ b/.github/workflows/build-openstack-baremetal-operator.yaml
@@ -4,20 +4,6 @@ on:
   push:
     branches:
       - '*'
-    paths-ignore:
-      - .gitignore
-      - .pull_request_pipeline
-      - changelog.txt
-      - kuttl-test.yaml
-      - LICENSE
-      - Makefile
-      - OWNERS
-      - PROJECT
-      - README.md
-      - .github/
-      - build/
-      - docs/
-      - tests/
 
 env:
   imageregistry: 'quay.io'


### PR DESCRIPTION
renovate will bump the openstack-operator even if there was no build done. Lets always build images.