### PR TITLE
Refactor validation logic to use in dataplane

### DIFF
--- a/api/v1beta1/openstackbaremetalset.go
+++ b/api/v1beta1/openstackbaremetalset.go
@@ -74,7 +74,7 @@ func VerifyBaremetalStatusBmhRefs(
 		}
 
 		if !found {
-			err := fmt.Errorf("Existing BaremetalHost \"%s\" not found for OpenStackBaremetalSet %s.  "+
+			err := fmt.Errorf("existing BaremetalHost \"%s\" not found for OpenStackBaremetalSet %s.  "+
 				"Please check BaremetalHost resources and re-add \"%s\" to continue",
 				bmhStatus.BmhRef, instance.Name, bmhStatus.BmhRef)
 
@@ -143,7 +143,7 @@ func VerifyBaremetalSetScaleUp(
 				errLabelStr = fmt.Sprintf(" with labels %s", labelStr)
 			}
 
-			return nil, fmt.Errorf("Unable to find %d requested BaremetalHosts%s in namespace %s for scale-up (%d in use, %d available)",
+			return nil, fmt.Errorf("unable to find %d requested BaremetalHosts%s in namespace %s for scale-up (%d in use, %d available)",
 				len(instance.Spec.BaremetalHosts),
 				errLabelStr,
 				instance.Spec.BmhNamespace,
@@ -166,7 +166,7 @@ func VerifyBaremetalSetScaleDown(
 	bmhsToRemoveCount := len(existingBmhs.Items) - len(instance.Spec.BaremetalHosts)
 
 	if bmhsToRemoveCount > removalAnnotatedBmhCount {
-		return fmt.Errorf("Unable to find sufficient amount of BaremetalHosts annotated for scale-down (%d found, %d requested)",
+		return fmt.Errorf("unable to find sufficient amount of BaremetalHosts annotated for scale-down (%d found, %d requested)",
 			removalAnnotatedBmhCount,
 			bmhsToRemoveCount)
 	}


### PR DESCRIPTION
We can't use the whole of validation logic in dataplane webhook without reference to the baremetalset objects. Refactor part of it which vlidates the changes to bmhLabelSelector and hardwareReqs so that we can use it in dataplane webhook.

Also, changes some error strings to start with smallcase.