### PR TITLE
This change ensures the baremetal-operator is built with FIPS compliance

### DIFF
--- a/.prow_ci.env
+++ b/.prow_ci.env
@@ -1,1 +1,2 @@
 export USE_IMAGE_DIGESTS=true
+export FAIL_FIPS_CHECK=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
-ARG GOLANG_BUILDER=golang:1.19
-ARG OPERATOR_BASE_IMAGE=gcr.io/distroless/static:nonroot
-ARG TARGETOS
-ARG TARGETARCH
+ARG GOLANG_BUILDER=registry.access.redhat.com/ubi9/go-toolset:1.19
+ARG OPERATOR_BASE_IMAGE=registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 # Build the manager binary
 FROM $GOLANG_BUILDER AS builder
@@ -14,11 +12,13 @@ ARG REMOTE_SOURCE_DIR=/remote-source
 ARG REMOTE_SOURCE_SUBDIR=
 ARG DEST_ROOT=/dest-root
 
-ARG GO_BUILD_EXTRA_ARGS=
+ARG GO_BUILD_EXTRA_ARGS="-tags strictfipsruntime"
+ARG GO_BUILD_EXTRA_ENV_ARGS="CGO_ENABLED=1 GO111MODULE=on"
 
 COPY $REMOTE_SOURCE $REMOTE_SOURCE_DIR
 WORKDIR $REMOTE_SOURCE_DIR/$REMOTE_SOURCE_SUBDIR
 
+USER root
 RUN mkdir -p ${DEST_ROOT}/usr/local/bin/
 
 # cache deps before building and copying source so that we don't need to re-download as much
@@ -26,7 +26,7 @@ RUN mkdir -p ${DEST_ROOT}/usr/local/bin/
 RUN if [ ! -f $CACHITO_ENV_FILE ]; then go mod download ; fi
 
 # Build manager
-RUN if [ -f $CACHITO_ENV_FILE ] ; then source $CACHITO_ENV_FILE ; fi ; CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} GO111MODULE=on go build ${GO_BUILD_EXTRA_ARGS} -a -o ${DEST_ROOT}/manager main.go
+RUN if [ -f $CACHITO_ENV_FILE ] ; then source $CACHITO_ENV_FILE ; fi ; env ${GO_BUILD_EXTRA_ENV_ARGS} go build ${GO_BUILD_EXTRA_ARGS} -a -o ${DEST_ROOT}/manager main.go
 
 RUN cp -r templates ${DEST_ROOT}/templates
 
@@ -51,16 +51,16 @@ ARG IMAGE_TAGS="cn-openstack openstack"
 
 # Labels required by upstream and osbs build system
 LABEL com.redhat.component="${IMAGE_COMPONENT}" \
-      name="${IMAGE_NAME}" \
-      version="${IMAGE_VERSION}" \
-      summary="${IMAGE_SUMMARY}" \
-      io.k8s.name="${IMAGE_NAME}" \
-      io.k8s.description="${IMAGE_DESC}" \
-      io.openshift.tags="${IMAGE_TAGS}"
+  name="${IMAGE_NAME}" \
+  version="${IMAGE_VERSION}" \
+  summary="${IMAGE_SUMMARY}" \
+  io.k8s.name="${IMAGE_NAME}" \
+  io.k8s.description="${IMAGE_DESC}" \
+  io.openshift.tags="${IMAGE_TAGS}"
 ### DO NOT EDIT LINES ABOVE
 
 ENV USER_UID=$USER_ID \
-    OPERATOR_TEMPLATES=/usr/share/openstack-baremetal-operator/templates/
+  OPERATOR_TEMPLATES=/usr/share/openstack-baremetal-operator/templates/
 
 WORKDIR /
 

--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,9 @@ endif
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
+# Extra vars which will be passed to the Docker-build
+DOCKER_BUILD_ARGS ?=
+
 .PHONY: all
 all: build
 
@@ -142,7 +145,7 @@ run: manifests generate fmt vet ## Run a controller from your host.
 # More info: https://docs.docker.com/develop/develop-images/build_enhancements/
 .PHONY: docker-build
 docker-build: test ## Build docker image with the manager.
-	podman build -t ${IMG} .
+	podman build -t ${IMG} . ${DOCKER_BUILD_ARGS}
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.


### PR DESCRIPTION
- Changed the build image to `ubi9/go-toolkit`
- Changed the base image to `ubi9/minimal`
- Added the default `GO_BUILD_EXTRA_ARGS="-tags strictfipsruntime"`
- Added the `GO_BUILD_EXTRA_ENV_ARGS` build argument to allow custom build arguments at build time. It defaults to `"CGO_ENABLED=1 GO111MODULE=on"`
- Those default parameters have been added to enable FIPS compliance
- Fixed indentation in Dockerfile
- Removed `TARGETOS` and `TARGETARCH` env vars.
- Added `DOCKER_BUILD_ARGS` variable in Makefile to pass custom parameters during podman build
- Added export `FAIL_FIPS_CHECK=true` in `.prow_ci.env` file to enable FIPS tests on prow

Closes: https://issues.redhat.com/browse/OSPRH-3375