### PR TITLE
Expose provision server images in baremetal set

### DIFF
--- a/api/bases/baremetal.openstack.org_openstackbaremetalsets.yaml
+++ b/api/bases/baremetal.openstack.org_openstackbaremetalsets.yaml
@@ -49,6 +49,14 @@ spec:
           spec:
             description: OpenStackBaremetalSetSpec defines the desired state of OpenStackBaremetalSet
             properties:
+              agentImageUrl:
+                description: AgentImageURL - Container image URL for the sidecar container
+                  that discovers provisioning network IPs
+                type: string
+              apacheImageUrl:
+                description: ApacheImageURL - Container image URL for the main container
+                  that serves the downloaded OS qcow2 image (osImage)
+                type: string
               automatedCleaningMode:
                 default: metadata
                 description: When set to disabled, automated cleaning will be avoided
@@ -247,6 +255,10 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
+              osContainerImageUrl:
+                description: OSContainerImageURL - Container image URL for init with
+                  the OS qcow2 image (osImage)
+                type: string
               osImage:
                 description: OSImage - OS qcow2 image Name
                 type: string

--- a/api/v1beta1/openstackbaremetalset_types.go
+++ b/api/v1beta1/openstackbaremetalset_types.go
@@ -54,6 +54,15 @@ type OpenStackBaremetalSetSpec struct {
 	// OSImage - OS qcow2 image Name
 	OSImage string `json:"osImage,omitempty"`
 	// +kubebuilder:validation:Optional
+	// OSContainerImageURL - Container image URL for init with the OS qcow2 image (osImage)
+	OSContainerImageURL string `json:"osContainerImageUrl,omitempty"`
+	// +kubebuilder:validation:Optional
+	// ApacheImageURL - Container image URL for the main container that serves the downloaded OS qcow2 image (osImage)
+	ApacheImageURL string `json:"apacheImageUrl,omitempty"`
+	// +kubebuilder:validation:Optional
+	// AgentImageURL - Container image URL for the sidecar container that discovers provisioning network IPs
+	AgentImageURL string `json:"agentImageUrl,omitempty"`
+	// +kubebuilder:validation:Optional
 	// UserData holds the reference to the Secret containing the user
 	// data to be passed to the host before it boots. UserData can be
 	// set per host in BaremetalHosts or here. If none of these are

--- a/config/crd/bases/baremetal.openstack.org_openstackbaremetalsets.yaml
+++ b/config/crd/bases/baremetal.openstack.org_openstackbaremetalsets.yaml
@@ -49,6 +49,14 @@ spec:
           spec:
             description: OpenStackBaremetalSetSpec defines the desired state of OpenStackBaremetalSet
             properties:
+              agentImageUrl:
+                description: AgentImageURL - Container image URL for the sidecar container
+                  that discovers provisioning network IPs
+                type: string
+              apacheImageUrl:
+                description: ApacheImageURL - Container image URL for the main container
+                  that serves the downloaded OS qcow2 image (osImage)
+                type: string
               automatedCleaningMode:
                 default: metadata
                 description: When set to disabled, automated cleaning will be avoided
@@ -247,6 +255,10 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
+              osContainerImageUrl:
+                description: OSContainerImageURL - Container image URL for init with
+                  the OS qcow2 image (osImage)
+                type: string
               osImage:
                 description: OSImage - OS qcow2 image Name
                 type: string

--- a/controllers/openstackbaremetalset_controller.go
+++ b/controllers/openstackbaremetalset_controller.go
@@ -485,6 +485,9 @@ func (r *OpenStackBaremetalSetReconciler) provisionServerCreateOrUpdate(
 		}
 
 		provisionServer.Spec.OSImage = instance.Spec.OSImage
+		provisionServer.Spec.OSContainerImageURL = instance.Spec.OSContainerImageURL
+		provisionServer.Spec.ApacheImageURL = instance.Spec.ApacheImageURL
+		provisionServer.Spec.AgentImageURL = instance.Spec.AgentImageURL
 		provisionServer.Spec.Interface = instance.Spec.ProvisioningInterface
 
 		err = controllerutil.SetControllerReference(instance, provisionServer, helper.GetScheme())


### PR DESCRIPTION
This change is proposed so that a custom osContainerImageUrl can be provided in the dataplane spec. This makes it possible to deploy a modified image for purposes including hotfixes and custom hardware.

Other container images are also exposed for completeness.