### PR TITLE
Add IPv6 support for networkdata

### DIFF
--- a/api/bases/baremetal.openstack.org_openstackbaremetalsets.yaml
+++ b/api/bases/baremetal.openstack.org_openstackbaremetalsets.yaml
@@ -70,7 +70,7 @@ spec:
                   description: InstanceSpec Instance specific attributes
                   properties:
                     ctlPlaneIP:
-                      description: CtlPlaneIP - Control Plane IP
+                      description: CtlPlaneIP - Control Plane IP in CIDR notation
                       type: string
                     networkData:
                       description: NetworkData - Host Network Data

--- a/api/v1beta1/openstackbaremetalset_types.go
+++ b/api/v1beta1/openstackbaremetalset_types.go
@@ -29,7 +29,7 @@ type AutomatedCleaningMode string
 // InstanceSpec Instance specific attributes
 type InstanceSpec struct {
 	// +kubebuilder:validation:Optional
-	// CtlPlaneIP - Control Plane IP
+	// CtlPlaneIP - Control Plane IP in CIDR notation
 	CtlPlaneIP string `json:"ctlPlaneIP"`
 	// +kubebuilder:validation:Optional
 	// UserData - Host User Data

--- a/config/crd/bases/baremetal.openstack.org_openstackbaremetalsets.yaml
+++ b/config/crd/bases/baremetal.openstack.org_openstackbaremetalsets.yaml
@@ -70,7 +70,7 @@ spec:
                   description: InstanceSpec Instance specific attributes
                   properties:
                     ctlPlaneIP:
-                      description: CtlPlaneIP - Control Plane IP
+                      description: CtlPlaneIP - Control Plane IP in CIDR notation
                       type: string
                     networkData:
                       description: NetworkData - Host Network Data

--- a/config/samples/baremetal_v1beta1_openstackbaremetalset.yaml
+++ b/config/samples/baremetal_v1beta1_openstackbaremetalset.yaml
@@ -6,8 +6,8 @@ spec:
   # Define how many BaremetalHosts are desired to be provisioned and assign
   # a control plane IP to them
   baremetalHosts:
-    compute-0: 172.22.0.100
-    compute-1: 172.22.0.101
+    compute-0: 172.22.0.100/24
+    compute-1: 172.22.0.101/24
   # The image to install on the provisioned nodes
   osImage: edpm-hardened-uefi.qcow2
   # provisionServerName: openstack  # uncomment if you pre-deploy a separate OsProvServer (use its name for the value)
@@ -17,7 +17,6 @@ spec:
   # The interface on the nodes that will be assigned an IP from the mgmtCidr
   ctlplaneInterface: enp1s0
   ctlplaneGateway: 172.22.0.3
-  ctlplaneNetmask: 255.255.255.0
   # An optional secret holding a data entry called "NodeRootPassword"
   # This will be set as the root password on all provisioned BaremetalHosts
   passwordSecret: baremetalset-password-secret

--- a/templates/openstackbaremetalset/cloudinit/networkdata
+++ b/templates/openstackbaremetalset/cloudinit/networkdata
@@ -3,13 +3,16 @@ links:
   id: {{ .CtlplaneInterface }}
   type: vif
 networks:
-- netmask: {{ .CtlplaneNetmask }}
-  link: {{ .CtlplaneInterface }}
+- link: {{ .CtlplaneInterface }}
   id: {{ .CtlplaneInterface }}
+  type: {{ .CtlplaneIpVersion }}
   ip_address: {{ .CtlplaneIp }}
-  type: ipv4
+  netmask: {{ .CtlplaneNetmask }}
 {{- if (index . "CtlplaneGateway") }}
-  gateway: {{ .CtlplaneGateway }}
+  routes:
+  - network: {{ if eq .CtlplaneIpVersion "ipv6" }}::{{ else }}0.0.0.0{{ end }}
+    netmask: {{ if eq .CtlplaneIpVersion "ipv6" }}::{{ else }}0.0.0.0{{ end }}
+    gateway: {{ .CtlplaneGateway }}
 {{- end }}
 {{- if not (eq (len .CtlplaneDns) 0) }}
 services:


### PR DESCRIPTION
Update the networkdata te

Change CtlPlaneIP to use a CIDR format (ip_addr/prefix).

Add a temporary compatibility layer utlizing a.b.c.d + CtlplaneNetmask to internally create the CIDR formated address.

In the future we can drop CtlplaneNetmask from OpenStackBaremetalSetSpec.