### PR TITLE
Ensure golangci-lint runs on all files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
 - repo: https://github.com/golangci/golangci-lint
   rev: v1.55.2
   hooks:
-    - id: golangci-lint
+    - id: golangci-lint-full
       args: ["-v"]
 
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/containers/agent/provision_ip_discovery.go
+++ b/containers/agent/provision_ip_discovery.go
@@ -46,7 +46,7 @@ func init() {
 	startCmd.PersistentFlags().StringVar(&startOpts.provServerNamespace, "prov-server-namespace", "", "Provisioning server resource namespace")
 }
 
-func runStartCmd(cmd *cobra.Command, args []string) {
+func runStartCmd(_ *cobra.Command, _ []string) {
 	var err error
 	err = flag.Set("logtostderr", "true")
 	if err != nil {
@@ -142,9 +142,8 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 					if ipObj = ipObj.To4(); ipObj != nil {
 						curIP = ipObj.String()
 						break
-					} else {
-						glog.V(0).Infof("INFO: Ignoring IPv6 address (%s) for OpenStackProvisionServer %s (namespace %s) on interface %s!\n", addr, startOpts.provServerName, startOpts.provServerName, startOpts.provIntf)
 					}
+					glog.V(0).Infof("INFO: Ignoring IPv6 address (%s) for OpenStackProvisionServer %s (namespace %s) on interface %s!\n", addr, startOpts.provServerName, startOpts.provServerName, startOpts.provIntf)
 				}
 				break
 			}

--- a/containers/agent/version.go
+++ b/containers/agent/version.go
@@ -20,7 +20,7 @@ func init() {
 	rootCmd.AddCommand(versionCmd)
 }
 
-func runVersionCmd(cmd *cobra.Command, args []string) {
+func runVersionCmd(_ *cobra.Command, _ []string) {
 	err := flag.Set("logtostderr", "true")
 	if err != nil {
 		panic(err.Error())

--- a/controllers/openstackbaremetalset_controller.go
+++ b/controllers/openstackbaremetalset_controller.go
@@ -37,7 +37,6 @@ import (
 
 	"github.com/go-logr/logr"
 	metal3v1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
-	"github.com/openstack-k8s-operators/lib-common/modules/common"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/env"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
@@ -203,10 +202,9 @@ func (r *OpenStackBaremetalSetReconciler) reconcileDelete(ctx context.Context, i
 }
 
 func (r *OpenStackBaremetalSetReconciler) reconcileInit(
-	ctx context.Context,
+	_ context.Context,
 	instance *baremetalv1.OpenStackBaremetalSet,
-	helper *helper.Helper,
-	serviceLabels map[string]string,
+	_ *helper.Helper,
 ) (ctrl.Result, error) {
 	r.Log.Info(fmt.Sprintf("Reconciling OpenStackBaremetalSet '%s' init", instance.Name))
 
@@ -214,7 +212,7 @@ func (r *OpenStackBaremetalSetReconciler) reconcileInit(
 	return ctrl.Result{}, nil
 }
 
-func (r *OpenStackBaremetalSetReconciler) reconcileUpdate(ctx context.Context, instance *baremetalv1.OpenStackBaremetalSet, helper *helper.Helper) (ctrl.Result, error) {
+func (r *OpenStackBaremetalSetReconciler) reconcileUpdate(_ context.Context, instance *baremetalv1.OpenStackBaremetalSet, _ *helper.Helper) (ctrl.Result, error) {
 	r.Log.Info(fmt.Sprintf("Reconciling OpenStackBaremetalSet '%s' update", instance.Name))
 
 	// TODO: should have minor update tasks if required
@@ -224,7 +222,7 @@ func (r *OpenStackBaremetalSetReconciler) reconcileUpdate(ctx context.Context, i
 	return ctrl.Result{}, nil
 }
 
-func (r *OpenStackBaremetalSetReconciler) reconcileUpgrade(ctx context.Context, instance *baremetalv1.OpenStackBaremetalSet, helper *helper.Helper) (ctrl.Result, error) {
+func (r *OpenStackBaremetalSetReconciler) reconcileUpgrade(_ context.Context, instance *baremetalv1.OpenStackBaremetalSet, _ *helper.Helper) (ctrl.Result, error) {
 	r.Log.Info(fmt.Sprintf("Reconciling OpenStackBaremetalSet '%s' upgrade", instance.Name))
 
 	// TODO: should have major version upgrade tasks
@@ -301,12 +299,8 @@ func (r *OpenStackBaremetalSetReconciler) reconcileNormal(ctx context.Context, i
 	// TODO check when/if Init, Update, or Upgrade should/could be skipped
 	//
 
-	serviceLabels := labels.GetLabels(instance, openstackprovisionserver.AppLabel, map[string]string{
-		common.AppSelector: instance.Name + "-deployment",
-	})
-
 	// Handle service init
-	ctrlResult, err := r.reconcileInit(ctx, instance, helper, serviceLabels)
+	ctrlResult, err := r.reconcileInit(ctx, instance, helper)
 	if err != nil {
 		return ctrlResult, err
 	} else if (ctrlResult != ctrl.Result{}) {

--- a/controllers/openstackprovisionserver_controller.go
+++ b/controllers/openstackprovisionserver_controller.go
@@ -241,7 +241,7 @@ func (r *OpenStackProvisionServerReconciler) SetupWithManager(mgr ctrl.Manager) 
 		Complete(r)
 }
 
-func (r *OpenStackProvisionServerReconciler) reconcileDelete(ctx context.Context, instance *baremetalv1.OpenStackProvisionServer, helper *helper.Helper) (ctrl.Result, error) {
+func (r *OpenStackProvisionServerReconciler) reconcileDelete(_ context.Context, instance *baremetalv1.OpenStackProvisionServer, helper *helper.Helper) (ctrl.Result, error) {
 	r.Log.Info(fmt.Sprintf("Reconciling OpenStackProvisionServer '%s' delete", instance.Name))
 
 	controllerutil.RemoveFinalizer(instance, helper.GetFinalizer())
@@ -251,10 +251,9 @@ func (r *OpenStackProvisionServerReconciler) reconcileDelete(ctx context.Context
 }
 
 func (r *OpenStackProvisionServerReconciler) reconcileInit(
-	ctx context.Context,
+	_ context.Context,
 	instance *baremetalv1.OpenStackProvisionServer,
-	helper *helper.Helper,
-	serviceLabels map[string]string,
+	_ *helper.Helper,
 ) (ctrl.Result, error) {
 	r.Log.Info(fmt.Sprintf("Reconciling OpenStackProvisionServer '%s' init", instance.Name))
 
@@ -262,7 +261,7 @@ func (r *OpenStackProvisionServerReconciler) reconcileInit(
 	return ctrl.Result{}, nil
 }
 
-func (r *OpenStackProvisionServerReconciler) reconcileUpdate(ctx context.Context, instance *baremetalv1.OpenStackProvisionServer, helper *helper.Helper) (ctrl.Result, error) {
+func (r *OpenStackProvisionServerReconciler) reconcileUpdate(_ context.Context, instance *baremetalv1.OpenStackProvisionServer, _ *helper.Helper) (ctrl.Result, error) {
 	r.Log.Info(fmt.Sprintf("Reconciling OpenStackProvisionServer '%s' update", instance.Name))
 
 	// TODO: should have minor update tasks if required
@@ -272,7 +271,7 @@ func (r *OpenStackProvisionServerReconciler) reconcileUpdate(ctx context.Context
 	return ctrl.Result{}, nil
 }
 
-func (r *OpenStackProvisionServerReconciler) reconcileUpgrade(ctx context.Context, instance *baremetalv1.OpenStackProvisionServer, helper *helper.Helper) (ctrl.Result, error) {
+func (r *OpenStackProvisionServerReconciler) reconcileUpgrade(_ context.Context, instance *baremetalv1.OpenStackProvisionServer, _ *helper.Helper) (ctrl.Result, error) {
 	r.Log.Info(fmt.Sprintf("Reconciling OpenStackProvisionServer '%s' upgrade", instance.Name))
 
 	// TODO: should have major version upgrade tasks
@@ -311,7 +310,7 @@ func (r *OpenStackProvisionServerReconciler) reconcileNormal(ctx context.Context
 	// create hash over all the different input resources to identify if any those changed
 	// and a restart/recreate is required.
 	//
-	inputHash, hashChanged, err := r.createHashOfInputHashes(ctx, instance, configMapVars)
+	inputHash, hashChanged, err := r.createHashOfInputHashes(instance, configMapVars)
 	if err != nil {
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.ServiceConfigReadyCondition,
@@ -352,7 +351,7 @@ func (r *OpenStackProvisionServerReconciler) reconcileNormal(ctx context.Context
 	})
 
 	// Handle service init
-	ctrlResult, err := r.reconcileInit(ctx, instance, helper, serviceLabels)
+	ctrlResult, err := r.reconcileInit(ctx, instance, helper)
 	if err != nil {
 		return ctrlResult, err
 	} else if (ctrlResult != ctrl.Result{}) {
@@ -486,7 +485,6 @@ func (r *OpenStackProvisionServerReconciler) generateServiceConfigMaps(
 //
 // returns the hash, whether the hash changed (as a bool) and any error
 func (r *OpenStackProvisionServerReconciler) createHashOfInputHashes(
-	ctx context.Context,
 	instance *baremetalv1.OpenStackProvisionServer,
 	envVars map[string]env.Setter,
 ) (string, bool, error) {
@@ -518,7 +516,7 @@ func (r *OpenStackProvisionServerReconciler) getProvisioningInterfaceName(
 	} else {
 		r.Log.Info("Provisioning interface name not yet discovered, checking Metal3...")
 
-		provInterfaceName, err = r.getProvisioningInterface(ctx, instance)
+		provInterfaceName, err = r.getProvisioningInterface(ctx)
 
 		if err != nil {
 			return "", err
@@ -530,7 +528,6 @@ func (r *OpenStackProvisionServerReconciler) getProvisioningInterfaceName(
 
 func (r *OpenStackProvisionServerReconciler) getProvisioningInterface(
 	ctx context.Context,
-	instance *baremetalv1.OpenStackProvisionServer,
 ) (string, error) {
 	cfg, err := config.GetConfig()
 

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -20,8 +20,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo/v2" //revive:disable:dot-imports
+	. "github.com/onsi/gomega"    //revive:disable:dot-imports
 
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"

--- a/pkg/openstackprovisionserver/deployment.go
+++ b/pkg/openstackprovisionserver/deployment.go
@@ -93,6 +93,12 @@ func Deployment(
 			StartupProbe:   startupProbe,
 			ReadinessProbe: readinessProbe,
 			LivenessProbe:  livenessProbe,
+			Env: []corev1.EnvVar{
+				{
+					Name:  "CONFIG_HASH",
+					Value: configHash,
+				},
+			},
 		},
 	}
 


### PR DESCRIPTION
This needed the following adjustments:
* ignore revive dot-imports rule on ginkgo and gomega as dot import
  there is the recommended practice
* fixed a bug that the input hash was not included in the deployment's
  env
* removed unused parameters
* various small style fixes found by the linter
