### PR TITLE
Align with standardized status pattern used across operators

### DIFF
--- a/api/v1beta1/openstackbaremetalset_types.go
+++ b/api/v1beta1/openstackbaremetalset_types.go
@@ -270,9 +270,9 @@ type DiskSSDReq struct {
 // will need some of those functions to exist in this module/package to avoid import cycle errors
 //
 
-// IsReady - returns true if all requested BMHs are provisioned
+// IsReady - returns true if OpenStackBaremetalSet is reconciled successfully
 func (instance *OpenStackBaremetalSet) IsReady() bool {
-	return instance.Status.Conditions.IsTrue(OpenStackBaremetalSetBmhProvisioningReadyCondition)
+	return instance.Status.Conditions.IsTrue(condition.ReadyCondition)
 }
 
 //

--- a/api/v1beta1/openstackprovisionserver_types.go
+++ b/api/v1beta1/openstackprovisionserver_types.go
@@ -87,9 +87,9 @@ type OpenStackProvisionServerStatus struct {
 	LocalImageURL string `json:"localImageUrl,omitempty"`
 }
 
-// IsReady - returns true if service is ready to serve requests
+// IsReady - returns true if OpenStackProvisionServer is reconciled successfully
 func (instance *OpenStackProvisionServer) IsReady() bool {
-	return instance.Status.ReadyCount > 0 && instance.Status.LocalImageURL != ""
+	return instance.Status.Conditions.IsTrue(condition.ReadyCondition)
 }
 
 // +kubebuilder:object:root=true

--- a/controllers/openstackprovisionserver_controller.go
+++ b/controllers/openstackprovisionserver_controller.go
@@ -119,11 +119,18 @@ func (r *OpenStackProvisionServerReconciler) Reconcile(ctx context.Context, req 
 
 	// Always patch the instance status when exiting this function so we can persist any changes.
 	defer func() {
-		// update the overall status condition if service is ready
-		if instance.IsReady() {
-			instance.Status.Conditions.MarkTrue(condition.ReadyCondition, condition.ReadyMessage)
+		// update the Ready condition based on the sub conditions
+		if instance.Status.Conditions.AllSubConditionIsTrue() {
+			instance.Status.Conditions.MarkTrue(
+				condition.ReadyCondition, condition.ReadyMessage)
+		} else {
+			// something is not ready so reset the Ready condition
+			instance.Status.Conditions.MarkUnknown(
+				condition.ReadyCondition, condition.InitReason, condition.ReadyInitMessage)
+			// and recalculate it based on the state of the rest of the conditions
+			instance.Status.Conditions.Set(
+				instance.Status.Conditions.Mirror(condition.ReadyCondition))
 		}
-
 		err := helper.PatchInstance(ctx, instance)
 		if err != nil {
 			_err = err
@@ -433,7 +440,17 @@ func (r *OpenStackProvisionServerReconciler) reconcileNormal(ctx context.Context
 		r.Log.Info(fmt.Sprintf("OpenStackProvisionServer LocalImageURL changed: %s", instance.Status.LocalImageURL))
 	}
 
-	instance.Status.Conditions.MarkTrue(baremetalv1.OpenStackProvisionServerLocalImageURLReadyCondition, baremetalv1.OpenStackProvisionServerLocalImageURLReadyMessage)
+	if instance.Status.LocalImageURL != "" {
+		instance.Status.Conditions.MarkTrue(baremetalv1.OpenStackProvisionServerLocalImageURLReadyCondition, baremetalv1.OpenStackProvisionServerLocalImageURLReadyMessage)
+	} else {
+		instance.Status.Conditions.Set(condition.FalseCondition(
+			baremetalv1.OpenStackProvisionServerLocalImageURLReadyCondition,
+			condition.RequestedReason,
+			condition.SeverityInfo,
+			baremetalv1.OpenStackProvisionServerLocalImageURLReadyRunningMessage))
+
+		return ctrl.Result{RequeueAfter: time.Duration(10) * time.Second}, nil
+	}
 	// check ProvisionIp/LocalImageURL - end
 
 	r.Log.Info(fmt.Sprintf("Reconciled OpenStackProvisionServer '%s' successfully", instance.Name))


### PR DESCRIPTION
Improves the deferred-status function to use the standardized pattern found in all (or at least most) other operators.  This also allows any error messages to appear in the CLI to help the user more easily discover problems. 