### PR TITLE
Remove unused ServiceAccount field

### DIFF
--- a/api/bases/baremetal.openstack.org_openstackprovisionservers.yaml
+++ b/api/bases/baremetal.openstack.org_openstackprovisionservers.yaml
@@ -127,18 +127,12 @@ spec:
                       More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                     type: object
                 type: object
-              serviceAccount:
-                default: provisionserver
-                description: ServiceAccount - service account name used internally
-                  to provide ProvisionServer the default SA name
-                type: string
             required:
             - agentImageUrl
             - apacheImageUrl
             - osContainerImageUrl
             - osImage
             - port
-            - serviceAccount
             type: object
           status:
             description: OpenStackProvisionServerStatus defines the observed state

--- a/api/v1beta1/openstackprovisionserver_types.go
+++ b/api/v1beta1/openstackprovisionserver_types.go
@@ -67,10 +67,6 @@ type OpenStackProvisionServerSpec struct {
 	// Resources - Compute Resources required by this provision server (Limits/Requests).
 	// https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
-	// +kubebuilder:validation:Required
-	// ServiceAccount - service account name used internally to provide ProvisionServer the default SA name
-	// +kubebuilder:default="provisionserver"
-	ServiceAccount string `json:"serviceAccount"`
 }
 
 // OpenStackProvisionServerStatus defines the observed state of OpenStackProvisionServer

--- a/config/crd/bases/baremetal.openstack.org_openstackprovisionservers.yaml
+++ b/config/crd/bases/baremetal.openstack.org_openstackprovisionservers.yaml
@@ -127,18 +127,12 @@ spec:
                       More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                     type: object
                 type: object
-              serviceAccount:
-                default: provisionserver
-                description: ServiceAccount - service account name used internally
-                  to provide ProvisionServer the default SA name
-                type: string
             required:
             - agentImageUrl
             - apacheImageUrl
             - osContainerImageUrl
             - osImage
             - port
-            - serviceAccount
             type: object
           status:
             description: OpenStackProvisionServerStatus defines the observed state


### PR DESCRIPTION
We don't use the `ServiceAccount` field and it also seems to be absent from other operators