### PR TITLE
Quote certain fields in networkdata

### DIFF
--- a/templates/openstackbaremetalset/cloudinit/networkdata
+++ b/templates/openstackbaremetalset/cloudinit/networkdata
@@ -7,11 +7,11 @@ networks:
   id: {{ .CtlplaneInterface }}
   type: {{ .CtlplaneIpVersion }}
   ip_address: {{ .CtlplaneIp }}
-  netmask: {{ .CtlplaneNetmask }}
+  netmask: "{{ .CtlplaneNetmask }}"
 {{- if (index . "CtlplaneGateway") }}
   routes:
-  - network: {{ if eq .CtlplaneIpVersion "ipv6" }}::{{ else }}0.0.0.0{{ end }}
-    netmask: {{ if eq .CtlplaneIpVersion "ipv6" }}::{{ else }}0.0.0.0{{ end }}
+  - network: {{ if eq .CtlplaneIpVersion "ipv6" }}"::"{{ else }}0.0.0.0{{ end }}
+    netmask: {{ if eq .CtlplaneIpVersion "ipv6" }}"::"{{ else }}0.0.0.0{{ end }}
     gateway: {{ .CtlplaneGateway }}
 {{- end }}
 {{- if not (eq (len .CtlplaneDns) 0) }}


### PR DESCRIPTION
They fail when using ipv6 with unmarshalling error.

```
failed to provision: failed to unmarshal network_data.json from secret:
error converting YAML to JSON: yaml: line 10: mapping values are not
allowed in this context","errorVerbose":"error converting YAML to JSON:
```
Signed-off-by: rabi <ramishra@redhat.com>