### PR TITLE
Add PreprovisioningNetworkDataName to baremetalset spec

### DIFF
--- a/api/bases/baremetal.openstack.org_openstackbaremetalsets.yaml
+++ b/api/bases/baremetal.openstack.org_openstackbaremetalsets.yaml
@@ -85,6 +85,10 @@ spec:
                           type: string
                       type: object
                       x-kubernetes-map-type: atomic
+                    preprovisioningNetworkDataName:
+                      description: PreprovisioningNetworkDataName - NetwoData Secret
+                        name for Preprovisining in the local namespace
+                      type: string
                     userData:
                       description: UserData - Host User Data
                       properties:

--- a/api/v1beta1/openstackbaremetalset_types.go
+++ b/api/v1beta1/openstackbaremetalset_types.go
@@ -37,6 +37,9 @@ type InstanceSpec struct {
 	// +kubebuilder:validation:Optional
 	// NetworkData - Host Network Data
 	NetworkData *corev1.SecretReference `json:"networkData,omitempty"`
+	// +kubebuilder:validation:Optional
+	// PreprovisioningNetworkDataName - NetwoData Secret name for Preprovisining in the local namespace
+	PreprovisioningNetworkDataName string `json:"preprovisioningNetworkDataName,omitempty"`
 }
 
 // Allowed automated cleaning modes

--- a/config/crd/bases/baremetal.openstack.org_openstackbaremetalsets.yaml
+++ b/config/crd/bases/baremetal.openstack.org_openstackbaremetalsets.yaml
@@ -85,6 +85,10 @@ spec:
                           type: string
                       type: object
                       x-kubernetes-map-type: atomic
+                    preprovisioningNetworkDataName:
+                      description: PreprovisioningNetworkDataName - NetwoData Secret
+                        name for Preprovisining in the local namespace
+                      type: string
                     userData:
                       description: UserData - Host User Data
                       properties:

--- a/pkg/openstackbaremetalset/baremetalhost.go
+++ b/pkg/openstackbaremetalset/baremetalhost.go
@@ -205,6 +205,9 @@ func BaremetalHostProvision(
 		// Ensure AutomatedCleaningMode is set as per spec
 		foundBaremetalHost.Spec.AutomatedCleaningMode = metal3v1.AutomatedCleaningMode(instance.Spec.AutomatedCleaningMode)
 
+		// Ensure PreprovisioningNetworkDataName is set as per spec
+		foundBaremetalHost.Spec.PreprovisioningNetworkDataName = instance.Spec.BaremetalHosts[hostName].PreprovisioningNetworkDataName
+
 		//
 		// Ensure the image url is up to date unless already provisioned
 		//


### PR DESCRIPTION
This is the name of the Secret in the local namespace containing network configuration (e.g content of network_data.json) which is passed to the preprovisioning image. It is also passed to the Config Drive if not overridden by specifying NetworkData.

jira: https://issues.redhat.com/browse/OSPRH-5641