### PR TITLE
Don't override preprovisioningNetworkDataName

### DIFF
--- a/pkg/openstackbaremetalset/baremetalhost.go
+++ b/pkg/openstackbaremetalset/baremetalhost.go
@@ -206,7 +206,10 @@ func BaremetalHostProvision(
 		foundBaremetalHost.Spec.AutomatedCleaningMode = metal3v1.AutomatedCleaningMode(instance.Spec.AutomatedCleaningMode)
 
 		// Ensure PreprovisioningNetworkDataName is set as per spec
-		foundBaremetalHost.Spec.PreprovisioningNetworkDataName = instance.Spec.BaremetalHosts[hostName].PreprovisioningNetworkDataName
+		preprovNetworkData := instance.Spec.BaremetalHosts[hostName].PreprovisioningNetworkDataName
+		if preprovNetworkData != "" {
+			foundBaremetalHost.Spec.PreprovisioningNetworkDataName = preprovNetworkData
+		}
 
 		//
 		// Ensure the image url is up to date unless already provisioned


### PR DESCRIPTION
If already set in the BMH and not provided in baremetalSpec don't override preprovisioningNetworkDataName.