### PR TITLE
Ensure ssh_authorized_keys is a list in cloud-init

### DIFF
--- a/templates/openstackbaremetalset/cloudinit/userdata
+++ b/templates/openstackbaremetalset/cloudinit/userdata
@@ -4,7 +4,12 @@ hostname: {{ .HostName }}
 fqdn: {{ .FQDN }}
 users:
   - name: {{ .CloudUserName }}
-    ssh-authorized-keys: {{ .AuthorizedKeys }}
+    ssh_authorized_keys:
+{{ range $ssh_key := .AuthorizedKeys }}
+{{ if not (eq $ssh_key "") }}
+      - {{ $ssh_key }}
+{{ end }}
+{{ end }}
     sudo: ['ALL=(ALL) NOPASSWD:ALL']
     shell: /bin/bash
 {{- if (index . "NodeRootPassword") }}


### PR DESCRIPTION
According to the official documentation[1], `ssh_authorized_keys` is a
list, not a string.

This patch should hopefully correct the issue we faced while trying to
inject multiple authorized keys: the cloud-init configuration file was
broken, preventing to apply any credential related data, leading to
failures when RHOSO deploy actually started.

[1] https://cloudinit.readthedocs.io/en/latest/reference/examples.html#configure-instance-s-ssh-keys

Co-Authored-By: @pablintino <pabrodri@redhat.com>
