### PR TITLE
[OSPRH-6776] Allow customizable OSImage checksum file suffix

### DIFF
--- a/api/bases/baremetal.openstack.org_openstackbaremetalsets.yaml
+++ b/api/bases/baremetal.openstack.org_openstackbaremetalsets.yaml
@@ -266,6 +266,11 @@ spec:
               osImage:
                 description: OSImage - OS qcow2 image Name
                 type: string
+              osImageChecksumSuffix:
+                default: sha256
+                description: OSImageChecksumSuffix - The file extension suffix on
+                  the OSImage checksum
+                type: string
               passwordSecret:
                 description: 'PasswordSecret the name of the secret used to optionally
                   set the root pwd by adding NodeRootPassword: <base64 enc pwd> to

--- a/api/v1beta1/openstackbaremetalset_types.go
+++ b/api/v1beta1/openstackbaremetalset_types.go
@@ -56,6 +56,10 @@ type OpenStackBaremetalSetSpec struct {
 	// +kubebuilder:validation:Optional
 	// OSImage - OS qcow2 image Name
 	OSImage string `json:"osImage,omitempty"`
+	// +kubebuilder:default=sha256
+	// +kubebuilder:validation:Optional
+	// OSImageChecksumSuffix - The file extension suffix on the OSImage checksum
+	OSImageChecksumSuffix *string `json:"osImageChecksumSuffix,omitempty"`
 	// +kubebuilder:validation:Optional
 	// OSContainerImageURL - Container image URL for init with the OS qcow2 image (osImage)
 	OSContainerImageURL string `json:"osContainerImageUrl,omitempty"`

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -302,6 +302,11 @@ func (in *OpenStackBaremetalSetSpec) DeepCopyInto(out *OpenStackBaremetalSetSpec
 			(*out)[key] = *val.DeepCopy()
 		}
 	}
+	if in.OSImageChecksumSuffix != nil {
+		in, out := &in.OSImageChecksumSuffix, &out.OSImageChecksumSuffix
+		*out = new(string)
+		**out = **in
+	}
 	if in.UserData != nil {
 		in, out := &in.UserData, &out.UserData
 		*out = new(v1.SecretReference)

--- a/config/crd/bases/baremetal.openstack.org_openstackbaremetalsets.yaml
+++ b/config/crd/bases/baremetal.openstack.org_openstackbaremetalsets.yaml
@@ -266,6 +266,11 @@ spec:
               osImage:
                 description: OSImage - OS qcow2 image Name
                 type: string
+              osImageChecksumSuffix:
+                default: sha256
+                description: OSImageChecksumSuffix - The file extension suffix on
+                  the OSImage checksum
+                type: string
               passwordSecret:
                 description: 'PasswordSecret the name of the secret used to optionally
                   set the root pwd by adding NodeRootPassword: <base64 enc pwd> to

--- a/pkg/openstackbaremetalset/baremetalhost.go
+++ b/pkg/openstackbaremetalset/baremetalhost.go
@@ -217,7 +217,7 @@ func BaremetalHostProvision(
 		if foundBaremetalHost.Status.Provisioning.State != metal3v1.StateProvisioned {
 			foundBaremetalHost.Spec.Image = &metal3v1.Image{
 				URL:          localImageURL,
-				Checksum:     fmt.Sprintf("%s.sha256", localImageURL),
+				Checksum:     fmt.Sprintf("%s.%s", localImageURL, *instance.Spec.OSImageChecksumSuffix),
 				ChecksumType: metal3v1.SHA256,
 			}
 		}
@@ -230,7 +230,7 @@ func BaremetalHostProvision(
 			foundBaremetalHost.Spec.ConsumerRef = &corev1.ObjectReference{Name: instance.Name, Kind: instance.Kind, Namespace: instance.Namespace}
 			foundBaremetalHost.Spec.Image = &metal3v1.Image{
 				URL:          localImageURL,
-				Checksum:     fmt.Sprintf("%s.sha256", localImageURL),
+				Checksum:     fmt.Sprintf("%s.%s", localImageURL, *instance.Spec.OSImageChecksumSuffix),
 				ChecksumType: metal3v1.SHA256,
 			}
 			foundBaremetalHost.Spec.UserData = userDataSecret

--- a/tests/functional/openstackbaremetalset_controller_test.go
+++ b/tests/functional/openstackbaremetalset_controller_test.go
@@ -61,6 +61,8 @@ var _ = Describe("BaremetalSet Test", func() {
 			DeferCleanup(th.DeleteInstance, CreateBaremetalSet(baremetalSetName, DefaultBaremetalSetSpec(bmhName, false)))
 		})
 		It("should have the Spec fields initialized", func() {
+			checksumSuffix := "sha256"
+
 			baremetalSetInstance := GetBaremetalSet(baremetalSetName)
 			spec := baremetalv1.OpenStackBaremetalSetSpec{
 				BaremetalHosts: map[string]baremetalv1.InstanceSpec{
@@ -72,6 +74,7 @@ var _ = Describe("BaremetalSet Test", func() {
 					},
 				},
 				OSImage:               "",
+				OSImageChecksumSuffix: &checksumSuffix,
 				OSContainerImageURL:   "",
 				ApacheImageURL:        "",
 				AgentImageURL:         "",


### PR DESCRIPTION
We were hardcoding the `OSImage` checksum file suffix.  It is now configurable by the user to provide more flexibility.