### PR TITLE
Add agent builder to github workflows

### DIFF
--- a/.github/workflows/build-openstack-baremetal-operator.yaml
+++ b/.github/workflows/build-openstack-baremetal-operator.yaml
@@ -23,6 +23,7 @@ jobs:
 
   call-build-workflow:
     uses: openstack-k8s-operators/openstack-k8s-operators-ci/.github/workflows/reusable-build-operator.yaml@main
+    needs: [build-openstack-baremetal-operator-agent]
     with:
       operator_name: openstack-baremetal
       go_version: 1.20.x

--- a/.github/workflows/build-openstack-baremetal-operator.yaml
+++ b/.github/workflows/build-openstack-baremetal-operator.yaml
@@ -11,6 +11,16 @@ env:
   latesttag: latest
 
 jobs:
+  check-secrets:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check secrets are set
+        id: have-secrets
+        if: "${{ env.imagenamespace != '' }}"
+        run: echo "ok=true" >>$GITHUB_OUTPUT
+    outputs:
+      have-secrets: ${{ steps.have-secrets.outputs.ok }}
+
   call-build-workflow:
     uses: openstack-k8s-operators/openstack-k8s-operators-ci/.github/workflows/reusable-build-operator.yaml@main
     with:
@@ -23,3 +33,39 @@ jobs:
       QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
       REDHATIO_USERNAME: ${{ secrets.REDHATIO_USERNAME }}
       REDHATIO_PASSWORD: ${{ secrets.REDHATIO_PASSWORD }}
+
+  build-openstack-baremetal-operator-agent:
+    name: Build agent image using buildah
+    runs-on: ubuntu-latest
+    needs: [check-secrets]
+    if: needs.check-secrets.outputs.have-secrets == 'true'
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Get branch name
+      id: branch-name
+      uses: tj-actions/branch-names@v7.0.7
+
+    - name: Set latest tag for non main branch
+      if: "${{ steps.branch-name.outputs.current_branch != 'main' }}"
+      run: |
+        echo "latesttag=${{ steps.branch-name.outputs.current_branch }}-latest" >> $GITHUB_ENV
+
+    - name: Buildah Action
+      id: build-openstack-baremetal-operator-agent
+      uses: redhat-actions/buildah-build@v2
+      with:
+        image: openstack-baremetal-operator-agent
+        tags: ${{ env.latesttag }} ${{ github.sha }}
+        containerfiles: |
+          ./Dockerfile.agent
+
+    - name: Push agent To ${{ env.imageregistry }}
+      uses: redhat-actions/push-to-registry@v2
+      with:
+        image: ${{ steps.build-openstack-baremetal-operator-agent.outputs.image }}
+        tags: ${{ steps.build-openstack-baremetal-operator-agent.outputs.tags }}
+        registry:  ${{ env.imageregistry }}/${{ env.imagenamespace }}
+        username: ${{ secrets.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_PASSWORD }}


### PR DESCRIPTION
Build the openstack-baremetal-operator-agent image using GitHub Action
workflow. This follows the same pattern as OSP director Operator.

Signed-off-by: Leif Madsen <lmadsen@redhat.com>
