### PR TITLE
Omit ctlPlaneIP if empty

### DIFF
--- a/api/v1beta1/openstackbaremetalset_types.go
+++ b/api/v1beta1/openstackbaremetalset_types.go
@@ -30,7 +30,7 @@ type AutomatedCleaningMode string
 type InstanceSpec struct {
 	// +kubebuilder:validation:Optional
 	// CtlPlaneIP - Control Plane IP in CIDR notation
-	CtlPlaneIP string `json:"ctlPlaneIP"`
+	CtlPlaneIP string `json:"ctlPlaneIP,omitempty"`
 	// +kubebuilder:validation:Optional
 	// UserData - Host User Data
 	UserData *corev1.SecretReference `json:"userData,omitempty"`


### PR DESCRIPTION
It's possible that user provides `networkData` or `preprovisioningNetworkDataName` that would have the network configuration to be used for the nodes rather than what we configure with cloud-init.

Let's ignore if empty to avoid errors.