### PR TITLE
Watch for owned OpenStackProvisionServer

### DIFF
--- a/controllers/openstackbaremetalset_controller.go
+++ b/controllers/openstackbaremetalset_controller.go
@@ -183,7 +183,7 @@ func (r *OpenStackBaremetalSetReconciler) SetupWithManager(mgr ctrl.Manager) err
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&baremetalv1.OpenStackBaremetalSet{}).
-		Owns(&baremetalv1.OpenStackBaremetalSet{}).
+		Owns(&baremetalv1.OpenStackProvisionServer{}).
 		Watches(&metal3v1.BareMetalHost{}, openshiftMachineAPIBareMetalHostsFn).
 		Complete(r)
 }
@@ -500,7 +500,6 @@ func (r *OpenStackBaremetalSetReconciler) provisionServerCreateOrUpdate(
 		if err != nil {
 			return err
 		}
-
 		provisionServer.Spec.OSImage = instance.Spec.OSImage
 		provisionServer.Spec.OSContainerImageURL = instance.Spec.OSContainerImageURL
 		provisionServer.Spec.ApacheImageURL = instance.Spec.ApacheImageURL


### PR DESCRIPTION
At present you can delete the OpenStackProvisionServer and it won't be re-created and manual changes to it won't be reset.