### PR TITLE
Set status when only PreprovisioningNetworkDataName is used

### DIFF
--- a/pkg/openstackbaremetalset/baremetalhost.go
+++ b/pkg/openstackbaremetalset/baremetalhost.go
@@ -253,7 +253,11 @@ func BaremetalHostProvision(
 	// Update status with BMH provisioning details
 	//
 	bmhStatus.UserDataSecretName = userDataSecret.Name
-	bmhStatus.NetworkDataSecretName = networkDataSecret.Name
+	if networkDataSecret != nil {
+		bmhStatus.NetworkDataSecretName = networkDataSecret.Name
+	} else {
+		bmhStatus.NetworkDataSecretName = preProvNetworkData
+	}
 	bmhStatus.ProvisioningState = baremetalv1.ProvisioningState(foundBaremetalHost.Status.Provisioning.State)
 	instance.Status.BaremetalHosts[hostName] = bmhStatus
 


### PR DESCRIPTION
Set bmhStatus.NetworkDataSecretName correctly when only PreprovisioningNetworkDataName is provided.

[OSPRH-10411](https://issues.redhat.com/browse/OSPRH-10411)