### PR TITLE
Bump go-toolset for agent

### DIFF
--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -1,4 +1,4 @@
-ARG GOLANG_BUILDER=registry.access.redhat.com/ubi9/go-toolset:1.20
+ARG GOLANG_BUILDER=registry.access.redhat.com/ubi9/go-toolset:1.21
 ARG OPERATOR_BASE_IMAGE=registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 # Build the manager binary


### PR DESCRIPTION
This was missed when we bumped to 1.21.

Image build failed in https://github.com/openstack-k8s-operators/openstack-baremetal-operator/actions/runs/11123349986 and hence https://github.com/openstack-k8s-operators/openstack-operator/pull/1114 won't get the tag.