### PR TITLE
Remove PreprovisioningNetworkDataName

### DIFF
--- a/api/bases/baremetal.openstack.org_openstackbaremetalsets.yaml
+++ b/api/bases/baremetal.openstack.org_openstackbaremetalsets.yaml
@@ -91,10 +91,6 @@ spec:
                           type: string
                       type: object
                       x-kubernetes-map-type: atomic
-                    preprovisioningNetworkDataName:
-                      description: PreprovisioningNetworkDataName - NetwoData Secret
-                        name for Preprovisining in the local namespace
-                      type: string
                     userData:
                       description: UserData - Host User Data
                       properties:
@@ -249,22 +245,6 @@ spec:
                         type: object
                     type: object
                 type: object
-              networkData:
-                description: NetworkData holds the reference to the Secret containing
-                  network data to be passed to the hosts. NetworkData can be set per
-                  host in BaremetalHosts or here. If none of these are provided it
-                  will use default NetworkData to configure CtlPlaneIP.
-                properties:
-                  name:
-                    description: name is unique within a namespace to reference a
-                      secret resource.
-                    type: string
-                  namespace:
-                    description: namespace defines the space within which the secret
-                      name must be unique.
-                    type: string
-                type: object
-                x-kubernetes-map-type: atomic
               osContainerImageUrl:
                 description: OSContainerImageURL - Container image URL for init with
                   the OS qcow2 image (osImage)
@@ -296,22 +276,6 @@ spec:
                   with ProvisionServerName, it would be discovered from CBO.  This
                   is the provisioning interface on the OCP masters/workers.
                 type: string
-              userData:
-                description: UserData holds the reference to the Secret containing
-                  the user data to be passed to the host before it boots. UserData
-                  can be set per host in BaremetalHosts or here. If none of these
-                  are provided it will use a default cloud-config.
-                properties:
-                  name:
-                    description: name is unique within a namespace to reference a
-                      secret resource.
-                    type: string
-                  namespace:
-                    description: namespace defines the space within which the secret
-                      name must be unique.
-                    type: string
-                type: object
-                x-kubernetes-map-type: atomic
             required:
             - cloudUserName
             - ctlplaneInterface

--- a/api/v1beta1/openstackbaremetalset_types.go
+++ b/api/v1beta1/openstackbaremetalset_types.go
@@ -41,8 +41,6 @@ type InstanceSpec struct {
 	// NetworkData - Host Network Data
 	NetworkData *corev1.SecretReference `json:"networkData,omitempty"`
 	// +kubebuilder:validation:Optional
-	// PreprovisioningNetworkDataName - NetwoData Secret name for Preprovisining in the local namespace
-	PreprovisioningNetworkDataName string `json:"preprovisioningNetworkDataName,omitempty"`
 }
 
 // Allowed automated cleaning modes
@@ -68,18 +66,6 @@ type OpenStackBaremetalSetSpec struct {
 	// +kubebuilder:validation:Optional
 	// AgentImageURL - Container image URL for the sidecar container that discovers provisioning network IPs
 	AgentImageURL string `json:"agentImageUrl,omitempty"`
-	// +kubebuilder:validation:Optional
-	// UserData holds the reference to the Secret containing the user
-	// data to be passed to the host before it boots. UserData can be
-	// set per host in BaremetalHosts or here. If none of these are
-	// provided it will use a default cloud-config.
-	UserData *corev1.SecretReference `json:"userData,omitempty"`
-	// +kubebuilder:validation:Optional
-	// NetworkData holds the reference to the Secret containing network
-	// data to be passed to the hosts. NetworkData can be set per host in
-	// BaremetalHosts or here. If none of these are provided it will use
-	// default NetworkData to configure CtlPlaneIP.
-	NetworkData *corev1.SecretReference `json:"networkData,omitempty"`
 	// When set to disabled, automated cleaning will be avoided
 	// during provisioning and deprovisioning.
 	// +kubebuilder:default=metadata

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -309,16 +309,6 @@ func (in *OpenStackBaremetalSetSpec) DeepCopyInto(out *OpenStackBaremetalSetSpec
 			(*out)[key] = *val.DeepCopy()
 		}
 	}
-	if in.UserData != nil {
-		in, out := &in.UserData, &out.UserData
-		*out = new(v1.SecretReference)
-		**out = **in
-	}
-	if in.NetworkData != nil {
-		in, out := &in.NetworkData, &out.NetworkData
-		*out = new(v1.SecretReference)
-		**out = **in
-	}
 	if in.BmhLabelSelector != nil {
 		in, out := &in.BmhLabelSelector, &out.BmhLabelSelector
 		*out = make(map[string]string, len(*in))

--- a/config/crd/bases/baremetal.openstack.org_openstackbaremetalsets.yaml
+++ b/config/crd/bases/baremetal.openstack.org_openstackbaremetalsets.yaml
@@ -91,10 +91,6 @@ spec:
                           type: string
                       type: object
                       x-kubernetes-map-type: atomic
-                    preprovisioningNetworkDataName:
-                      description: PreprovisioningNetworkDataName - NetwoData Secret
-                        name for Preprovisining in the local namespace
-                      type: string
                     userData:
                       description: UserData - Host User Data
                       properties:
@@ -249,22 +245,6 @@ spec:
                         type: object
                     type: object
                 type: object
-              networkData:
-                description: NetworkData holds the reference to the Secret containing
-                  network data to be passed to the hosts. NetworkData can be set per
-                  host in BaremetalHosts or here. If none of these are provided it
-                  will use default NetworkData to configure CtlPlaneIP.
-                properties:
-                  name:
-                    description: name is unique within a namespace to reference a
-                      secret resource.
-                    type: string
-                  namespace:
-                    description: namespace defines the space within which the secret
-                      name must be unique.
-                    type: string
-                type: object
-                x-kubernetes-map-type: atomic
               osContainerImageUrl:
                 description: OSContainerImageURL - Container image URL for init with
                   the OS qcow2 image (osImage)
@@ -296,22 +276,6 @@ spec:
                   with ProvisionServerName, it would be discovered from CBO.  This
                   is the provisioning interface on the OCP masters/workers.
                 type: string
-              userData:
-                description: UserData holds the reference to the Secret containing
-                  the user data to be passed to the host before it boots. UserData
-                  can be set per host in BaremetalHosts or here. If none of these
-                  are provided it will use a default cloud-config.
-                properties:
-                  name:
-                    description: name is unique within a namespace to reference a
-                      secret resource.
-                    type: string
-                  namespace:
-                    description: namespace defines the space within which the secret
-                      name must be unique.
-                    type: string
-                type: object
-                x-kubernetes-map-type: atomic
             required:
             - cloudUserName
             - ctlplaneInterface

--- a/pkg/openstackbaremetalset/baremetalhost.go
+++ b/pkg/openstackbaremetalset/baremetalhost.go
@@ -51,17 +51,9 @@ func BaremetalHostProvision(
 		}
 		bmhStatus.IPAddresses["ctlplane"] = ctlPlaneIP
 	}
-	// Instance UserData/NetworkData overrides the default
+	// Instance UserData/NetworkData
 	userDataSecret := instance.Spec.BaremetalHosts[hostName].UserData
 	networkDataSecret := instance.Spec.BaremetalHosts[hostName].NetworkData
-
-	if userDataSecret == nil {
-		userDataSecret = instance.Spec.UserData
-	}
-
-	if networkDataSecret == nil {
-		networkDataSecret = instance.Spec.NetworkData
-	}
 
 	sts := []util.Template{}
 	// User data cloud-init secret
@@ -102,21 +94,7 @@ func BaremetalHostProvision(
 
 	}
 
-	//
-	// Provision the BaremetalHost
-	//
-	foundBaremetalHost := &metal3v1.BareMetalHost{}
-	err := helper.GetClient().Get(ctx, types.NamespacedName{Name: bmh, Namespace: instance.Spec.BmhNamespace}, foundBaremetalHost)
-	if err != nil {
-		return err
-	}
-
-	preProvNetworkData := foundBaremetalHost.Spec.PreprovisioningNetworkDataName
-	if preProvNetworkData == "" {
-		preProvNetworkData = instance.Spec.BaremetalHosts[hostName].PreprovisioningNetworkDataName
-	}
-
-	if networkDataSecret == nil && preProvNetworkData == "" {
+	if networkDataSecret == nil {
 
 		// Check IP version and set template variables accordingly
 		ipAddr, ipNet, err := net.ParseCIDR(ctlPlaneIP)
@@ -192,6 +170,14 @@ func BaremetalHostProvision(
 		}
 	}
 
+	//
+	// Provision the BaremetalHost
+	//
+	foundBaremetalHost := &metal3v1.BareMetalHost{}
+	err := helper.GetClient().Get(ctx, types.NamespacedName{Name: bmh, Namespace: instance.Spec.BmhNamespace}, foundBaremetalHost)
+	if err != nil {
+		return err
+	}
 	op, err := controllerutil.CreateOrPatch(ctx, helper.GetClient(), foundBaremetalHost, func() error {
 		// Set our ownership labels so we can watch this resource and also indicate that this BMH
 		// belongs to the particular OSBMS.Spec.BaremetalHosts entry we have passed to this function.
@@ -206,8 +192,6 @@ func BaremetalHostProvision(
 
 		// Ensure AutomatedCleaningMode is set as per spec
 		foundBaremetalHost.Spec.AutomatedCleaningMode = metal3v1.AutomatedCleaningMode(instance.Spec.AutomatedCleaningMode)
-
-		foundBaremetalHost.Spec.PreprovisioningNetworkDataName = preProvNetworkData
 
 		//
 		// Ensure the image url is up to date unless already provisioned
@@ -250,11 +234,7 @@ func BaremetalHostProvision(
 	// Update status with BMH provisioning details
 	//
 	bmhStatus.UserDataSecretName = userDataSecret.Name
-	if networkDataSecret != nil {
-		bmhStatus.NetworkDataSecretName = networkDataSecret.Name
-	} else {
-		bmhStatus.NetworkDataSecretName = preProvNetworkData
-	}
+	bmhStatus.NetworkDataSecretName = networkDataSecret.Name
 	bmhStatus.ProvisioningState = baremetalv1.ProvisioningState(foundBaremetalHost.Status.Provisioning.State)
 	instance.Status.BaremetalHosts[hostName] = bmhStatus
 

--- a/tests/functional/openstackbaremetalset_controller_test.go
+++ b/tests/functional/openstackbaremetalset_controller_test.go
@@ -65,19 +65,16 @@ var _ = Describe("BaremetalSet Test", func() {
 			spec := baremetalv1.OpenStackBaremetalSetSpec{
 				BaremetalHosts: map[string]baremetalv1.InstanceSpec{
 					"compute-0": {
-						CtlPlaneIP:                     "10.0.0.1",
-						UserData:                       nil,
-						NetworkData:                    nil,
-						PreprovisioningNetworkDataName: "",
-						BmhLabelSelector:               nil,
+						CtlPlaneIP:       "10.0.0.1",
+						UserData:         nil,
+						NetworkData:      nil,
+						BmhLabelSelector: nil,
 					},
 				},
 				OSImage:               "",
 				OSContainerImageURL:   "",
 				ApacheImageURL:        "",
 				AgentImageURL:         "",
-				UserData:              nil,
-				NetworkData:           nil,
 				AutomatedCleaningMode: "metadata",
 				ProvisionServerName:   "",
 				ProvisioningInterface: "",


### PR DESCRIPTION
We had initially introduced `preprovisioningNetworkDataName` field in `InstanceSpec` for users to have flexibility of setting it in `OpenStackDataPlaneNodeSet` CR for the individual nodes. We have had the implementation to fallback to using `preprovisioningNetworkDataName` for provisioning `networkData` if the later is not provided and the former is set.

However, we've noticed that this does not work when using coreos IPA ramdisk image as `ProvisioningImage` Builder expects the `preprovisioningNetworkDataName` to be in nmstate format, however for us during provisioning cloud-init expects it to be in openstack network_data.json format.

Therefore we would not replicate the metal3 behavior of falling back to `preprovisioningNetworkDataName` if `networkData` is not provided. We instead will keep both network data for preprovisionig and provisoning separate. If `networkData` is not provided per BMH node, we would use the default `networkData` we generate using IPAM.

This also removes networkData/userData from the BaremetalSet spec as there is no way user can provide this data for a set of BMHs.

Depends-On: https://github.com/openstack-k8s-operators/openstack-operator/pull/1116
jira: https://issues.redhat.com/browse/OSPRH-10442