### PR TITLE
Remove PreprovisioningNetworkData

### DIFF
--- a/api/bases/baremetal.openstack.org_openstackbaremetalsets.yaml
+++ b/api/bases/baremetal.openstack.org_openstackbaremetalsets.yaml
@@ -85,10 +85,6 @@ spec:
                           type: string
                       type: object
                       x-kubernetes-map-type: atomic
-                    preprovisioningNetworkDataName:
-                      description: PreprovisioningNetworkDataName - NetwoData Secret
-                        name for Preprovisining in the local namespace
-                      type: string
                     userData:
                       description: UserData - Host User Data
                       properties:
@@ -243,22 +239,6 @@ spec:
                         type: object
                     type: object
                 type: object
-              networkData:
-                description: NetworkData holds the reference to the Secret containing
-                  network data to be passed to the hosts. NetworkData can be set per
-                  host in BaremetalHosts or here. If none of these are provided it
-                  will use default NetworkData to configure CtlPlaneIP.
-                properties:
-                  name:
-                    description: name is unique within a namespace to reference a
-                      secret resource.
-                    type: string
-                  namespace:
-                    description: namespace defines the space within which the secret
-                      name must be unique.
-                    type: string
-                type: object
-                x-kubernetes-map-type: atomic
               osContainerImageUrl:
                 description: OSContainerImageURL - Container image URL for init with
                   the OS qcow2 image (osImage)
@@ -290,22 +270,6 @@ spec:
                   with ProvisionServerName, it would be discovered from CBO.  This
                   is the provisioning interface on the OCP masters/workers.
                 type: string
-              userData:
-                description: UserData holds the reference to the Secret containing
-                  the user data to be passed to the host before it boots. UserData
-                  can be set per host in BaremetalHosts or here. If none of these
-                  are provided it will use a default cloud-config.
-                properties:
-                  name:
-                    description: name is unique within a namespace to reference a
-                      secret resource.
-                    type: string
-                  namespace:
-                    description: namespace defines the space within which the secret
-                      name must be unique.
-                    type: string
-                type: object
-                x-kubernetes-map-type: atomic
             required:
             - cloudUserName
             - ctlplaneInterface

--- a/api/v1beta1/openstackbaremetalset_types.go
+++ b/api/v1beta1/openstackbaremetalset_types.go
@@ -38,8 +38,6 @@ type InstanceSpec struct {
 	// NetworkData - Host Network Data
 	NetworkData *corev1.SecretReference `json:"networkData,omitempty"`
 	// +kubebuilder:validation:Optional
-	// PreprovisioningNetworkDataName - NetwoData Secret name for Preprovisining in the local namespace
-	PreprovisioningNetworkDataName string `json:"preprovisioningNetworkDataName,omitempty"`
 }
 
 // Allowed automated cleaning modes
@@ -65,18 +63,6 @@ type OpenStackBaremetalSetSpec struct {
 	// +kubebuilder:validation:Optional
 	// AgentImageURL - Container image URL for the sidecar container that discovers provisioning network IPs
 	AgentImageURL string `json:"agentImageUrl,omitempty"`
-	// +kubebuilder:validation:Optional
-	// UserData holds the reference to the Secret containing the user
-	// data to be passed to the host before it boots. UserData can be
-	// set per host in BaremetalHosts or here. If none of these are
-	// provided it will use a default cloud-config.
-	UserData *corev1.SecretReference `json:"userData,omitempty"`
-	// +kubebuilder:validation:Optional
-	// NetworkData holds the reference to the Secret containing network
-	// data to be passed to the hosts. NetworkData can be set per host in
-	// BaremetalHosts or here. If none of these are provided it will use
-	// default NetworkData to configure CtlPlaneIP.
-	NetworkData *corev1.SecretReference `json:"networkData,omitempty"`
 	// When set to disabled, automated cleaning will be avoided
 	// during provisioning and deprovisioning.
 	// +kubebuilder:default=metadata

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -302,16 +302,6 @@ func (in *OpenStackBaremetalSetSpec) DeepCopyInto(out *OpenStackBaremetalSetSpec
 			(*out)[key] = *val.DeepCopy()
 		}
 	}
-	if in.UserData != nil {
-		in, out := &in.UserData, &out.UserData
-		*out = new(v1.SecretReference)
-		**out = **in
-	}
-	if in.NetworkData != nil {
-		in, out := &in.NetworkData, &out.NetworkData
-		*out = new(v1.SecretReference)
-		**out = **in
-	}
 	if in.BmhLabelSelector != nil {
 		in, out := &in.BmhLabelSelector, &out.BmhLabelSelector
 		*out = make(map[string]string, len(*in))

--- a/config/crd/bases/baremetal.openstack.org_openstackbaremetalsets.yaml
+++ b/config/crd/bases/baremetal.openstack.org_openstackbaremetalsets.yaml
@@ -85,10 +85,6 @@ spec:
                           type: string
                       type: object
                       x-kubernetes-map-type: atomic
-                    preprovisioningNetworkDataName:
-                      description: PreprovisioningNetworkDataName - NetwoData Secret
-                        name for Preprovisining in the local namespace
-                      type: string
                     userData:
                       description: UserData - Host User Data
                       properties:
@@ -243,22 +239,6 @@ spec:
                         type: object
                     type: object
                 type: object
-              networkData:
-                description: NetworkData holds the reference to the Secret containing
-                  network data to be passed to the hosts. NetworkData can be set per
-                  host in BaremetalHosts or here. If none of these are provided it
-                  will use default NetworkData to configure CtlPlaneIP.
-                properties:
-                  name:
-                    description: name is unique within a namespace to reference a
-                      secret resource.
-                    type: string
-                  namespace:
-                    description: namespace defines the space within which the secret
-                      name must be unique.
-                    type: string
-                type: object
-                x-kubernetes-map-type: atomic
               osContainerImageUrl:
                 description: OSContainerImageURL - Container image URL for init with
                   the OS qcow2 image (osImage)
@@ -290,22 +270,6 @@ spec:
                   with ProvisionServerName, it would be discovered from CBO.  This
                   is the provisioning interface on the OCP masters/workers.
                 type: string
-              userData:
-                description: UserData holds the reference to the Secret containing
-                  the user data to be passed to the host before it boots. UserData
-                  can be set per host in BaremetalHosts or here. If none of these
-                  are provided it will use a default cloud-config.
-                properties:
-                  name:
-                    description: name is unique within a namespace to reference a
-                      secret resource.
-                    type: string
-                  namespace:
-                    description: namespace defines the space within which the secret
-                      name must be unique.
-                    type: string
-                type: object
-                x-kubernetes-map-type: atomic
             required:
             - cloudUserName
             - ctlplaneInterface

--- a/tests/functional/openstackbaremetalset_controller_test.go
+++ b/tests/functional/openstackbaremetalset_controller_test.go
@@ -65,18 +65,15 @@ var _ = Describe("BaremetalSet Test", func() {
 			spec := baremetalv1.OpenStackBaremetalSetSpec{
 				BaremetalHosts: map[string]baremetalv1.InstanceSpec{
 					"compute-0": {
-						CtlPlaneIP:                     "10.0.0.1",
-						UserData:                       nil,
-						NetworkData:                    nil,
-						PreprovisioningNetworkDataName: "",
+						CtlPlaneIP:  "10.0.0.1",
+						UserData:    nil,
+						NetworkData: nil,
 					},
 				},
 				OSImage:               "",
 				OSContainerImageURL:   "",
 				ApacheImageURL:        "",
 				AgentImageURL:         "",
-				UserData:              nil,
-				NetworkData:           nil,
 				AutomatedCleaningMode: "metadata",
 				ProvisionServerName:   "",
 				ProvisioningInterface: "",


### PR DESCRIPTION
We had initially introduced preprovisioningNetworkDataName field in InstanceSpec for users to have flexibility of setting it in OpenStackDataPlaneNodeSet CR for the individual nodes. We have had the implementation to fallback to using preprovisioningNetworkDataName for networkData if the later is not provided and the former is set.

However, we've noticed that this does not work when using coreos IPA ramdisk image as ProvisioningImage Builder expects the preprovisioningNetworkDataName to be in nmstate format, however for us during provisioning cloud-init expects it to be in openstack network_data.json format.

Therefore we would not replicate the metal3 behavior of falling back to preprovisioningNetworkDataName if networkData is not provided. We instead will keep both network data for preprovisionig and provisoning separate. If networkData is not provided per BMH node, we would use the default networkData we generate using IPAM.

This also removes networkData/userData from the BaremetalSet spec as there is no way user can provide this data for a set of BMHs.

jira: https://issues.redhat.com/browse/OSPRH-10442