### PR TITLE
[OSPRH-11494] Make auto port assignment for OSProvServer cluster-scoped

### DIFF
--- a/api/v1beta1/openstackprovisionserver.go
+++ b/api/v1beta1/openstackprovisionserver.go
@@ -7,7 +7,7 @@ import (
 	goClient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// GetExistingProvServerPorts - Get all ports currently in use by all OpenStackProvisionServers in this namespace
+// GetExistingProvServerPorts - Get all ports currently in use by all OpenStackProvisionServers
 func GetExistingProvServerPorts(
 	ctx context.Context,
 	c goClient.Client,
@@ -17,9 +17,7 @@ func GetExistingProvServerPorts(
 
 	provServerList := &OpenStackProvisionServerList{}
 
-	listOpts := []goClient.ListOption{
-		goClient.InNamespace(instance.Namespace),
-	}
+	listOpts := []goClient.ListOption{}
 
 	err := c.List(ctx, provServerList, listOpts...)
 	if err != nil {
@@ -40,11 +38,6 @@ func AssignProvisionServerPort(
 	instance *OpenStackProvisionServer,
 	portStart int32,
 ) error {
-	if instance.Spec.Port != 0 {
-		// Do nothing, already assigned
-		return nil
-	}
-
 	existingPorts, err := GetExistingProvServerPorts(ctx, c, instance)
 	if err != nil {
 		return err

--- a/api/v1beta1/openstackprovisionserver_types.go
+++ b/api/v1beta1/openstackprovisionserver_types.go
@@ -35,6 +35,8 @@ const (
 	ProvisioningNetworkDisabled  ProvisioningNetwork = "Disabled"
 	// Checksum job hash
 	ChecksumHash = "checksum"
+	// DefaultProvisionPort - The starting default port for the OpenStackProvisionServer's Apache container
+	DefaultProvisionPort = 6190
 )
 
 const (

--- a/api/v1beta1/openstackprovisionserver_webhook.go
+++ b/api/v1beta1/openstackprovisionserver_webhook.go
@@ -115,4 +115,14 @@ func (r *OpenStackProvisionServer) Default() {
 	if r.Spec.OSImage == "" {
 		r.Spec.OSImage = openstackProvisionServerDefaults.OSImage
 	}
+	if r.Spec.Port == 0 {
+		err := AssignProvisionServerPort(context.TODO(), webhookClient, r, DefaultProvisionPort)
+		if err != nil {
+			// If this occurs, it will also be caught just after this defaulting webhook in the
+			// validating webhook, because that webhook calls the same underlying function that
+			// checks for the availability of ports.  That will cause the create/update of the
+			// CR to fail and halt moving forward.
+			openstackprovisionserverlog.Error(err, "Cannot assign port for OpenStackProvisionServer", "OpenStackProvisionServer", r)
+		}
+	}
 }

--- a/pkg/openstackprovisionserver/const.go
+++ b/pkg/openstackprovisionserver/const.go
@@ -20,9 +20,6 @@ const (
 	// AppLabel -
 	AppLabel = "osp-provisionserver"
 
-	// DefaultPort - The starting default port for the OpenStackProvisionServer's Apache container
-	DefaultPort = 6190
-
 	// HttpdConfPath -
 	HttpdConfPath = "/usr/local/apache2/conf/httpd.conf"
 )


### PR DESCRIPTION
Changes `OpenStackProvisionServer` auto-port-assignment to be cluster-scoped rather than namespaced.  This is necessary because provision server pods run with host networking.  Therefore, if two different provision server pods from two different namespaces are scheduled on the same node and use the same port, they will conflict and the second one will fail to run.  This resolves the problem by having the operator always consider the current port usage across all `OpenStackProvisionServer`s in the cluster when selecting a new port for a new `OpenStackProvisionServer`.  In this manner, we avoid duplicates in auto-generated port assignments.

Jira: [OSPRH-11494](https://issues.redhat.com//browse/OSPRH-11494)