### PR TITLE
Expose ProvisionServerNodeSelector in baremetalset spec

### DIFF
--- a/api/bases/baremetal.openstack.org_openstackbaremetalsets.yaml
+++ b/api/bases/baremetal.openstack.org_openstackbaremetalsets.yaml
@@ -268,9 +268,15 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               provisionServerName:
-                description: ProvisionServerName - Optional. If supplied will be used
-                  as the base Image for the baremetalset instead of baseImageURL.
+                description: ProvisionServerName - Optional. Existing OpenStackProvisionServer
+                  to use, else one would be created.
                 type: string
+              provisionServerNodeSelector:
+                additionalProperties:
+                  type: string
+                description: ProvisonServerNodeSelector to target subset of worker
+                  nodes running provision server
+                type: object
               provisioningInterface:
                 description: ProvisioningInterface - Optional. If not provided along
                   with ProvisionServerName, it would be discovered from CBO.  This

--- a/api/v1beta1/openstackbaremetalset_types.go
+++ b/api/v1beta1/openstackbaremetalset_types.go
@@ -71,9 +71,12 @@ type OpenStackBaremetalSetSpec struct {
 	// +kubebuilder:default=metadata
 	// +kubebuilder:validation:Optional
 	AutomatedCleaningMode AutomatedCleaningMode `json:"automatedCleaningMode,omitempty"`
-	// ProvisionServerName - Optional. If supplied will be used as the base Image for the baremetalset instead of baseImageURL.
+	// ProvisionServerName - Optional. Existing OpenStackProvisionServer to use, else one would be created.
 	// +kubebuilder:validation:Optional
 	ProvisionServerName string `json:"provisionServerName,omitempty"`
+	// +kubebuilder:validation:Optional
+	// ProvisonServerNodeSelector to target subset of worker nodes running provision server
+	ProvisonServerNodeSelector map[string]string `json:"provisionServerNodeSelector,omitempty"`
 	// ProvisioningInterface - Optional. If not provided along with ProvisionServerName, it would be discovered from CBO.  This is the provisioning interface on the OCP masters/workers.
 	// +kubebuilder:validation:Optional
 	ProvisioningInterface string `json:"provisioningInterface,omitempty"`

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -309,6 +309,13 @@ func (in *OpenStackBaremetalSetSpec) DeepCopyInto(out *OpenStackBaremetalSetSpec
 			(*out)[key] = *val.DeepCopy()
 		}
 	}
+	if in.ProvisonServerNodeSelector != nil {
+		in, out := &in.ProvisonServerNodeSelector, &out.ProvisonServerNodeSelector
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.BmhLabelSelector != nil {
 		in, out := &in.BmhLabelSelector, &out.BmhLabelSelector
 		*out = make(map[string]string, len(*in))

--- a/config/crd/bases/baremetal.openstack.org_openstackbaremetalsets.yaml
+++ b/config/crd/bases/baremetal.openstack.org_openstackbaremetalsets.yaml
@@ -268,9 +268,15 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               provisionServerName:
-                description: ProvisionServerName - Optional. If supplied will be used
-                  as the base Image for the baremetalset instead of baseImageURL.
+                description: ProvisionServerName - Optional. Existing OpenStackProvisionServer
+                  to use, else one would be created.
                 type: string
+              provisionServerNodeSelector:
+                additionalProperties:
+                  type: string
+                description: ProvisonServerNodeSelector to target subset of worker
+                  nodes running provision server
+                type: object
               provisioningInterface:
                 description: ProvisioningInterface - Optional. If not provided along
                   with ProvisionServerName, it would be discovered from CBO.  This

--- a/controllers/openstackbaremetalset_controller.go
+++ b/controllers/openstackbaremetalset_controller.go
@@ -518,6 +518,7 @@ func (r *OpenStackBaremetalSetReconciler) provisionServerCreateOrUpdate(
 		provisionServer.Spec.OSContainerImageURL = instance.Spec.OSContainerImageURL
 		provisionServer.Spec.ApacheImageURL = instance.Spec.ApacheImageURL
 		provisionServer.Spec.AgentImageURL = instance.Spec.AgentImageURL
+		provisionServer.Spec.NodeSelector = instance.Spec.ProvisonServerNodeSelector
 		provisionServer.Spec.Interface = instance.Spec.ProvisioningInterface
 
 		err = controllerutil.SetControllerReference(instance, provisionServer, helper.GetScheme())


### PR DESCRIPTION
This would allow selecting OCP nodes with specific networks to deploy OpenStackProvisionServer and avoid issues like assymetric routing when OSP networks are configured on some OCP worker nodes by setting  `provisionServerNodeSelector` in `baremetalSetTemplate` field of nodeset spec.

At present it's possible to pre-create OpenStackProvisionServer and use it in `baremetalSetTemplate` of OpenStackDaplaneNodeSet CR.

Jira: https://issues.redhat.com/browse/OSPRH-11665