### PR TITLE
[18.0-fr1][make]Add force-bump target to bump operator deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -385,3 +385,13 @@ run-with-webhook: export HEALTH_PORT?=8081
 run-with-webhook: manifests generate fmt vet ## Run a controller from your host.
 	/bin/bash hack/configure_local_webhook.sh
 	OPERATOR_TEMPLATES=./templates go run ./main.go -metrics-bind-address ":$(METRICS_PORT)" -health-probe-bind-address ":$(HEALTH_PORT)"
+
+BRANCH=18.0-fr1
+.PHONY: force-bump
+force-bump: ## Force bump operator and lib-common dependencies
+	for dep in $$(cat go.mod | grep openstack-k8s-operators | grep -vE -- 'indirect|openstack-baremetal-operator|^replace' | awk '{print $$1}'); do \
+		go get $$dep@$(BRANCH) ; \
+	done
+	for dep in $$(cat api/go.mod | grep openstack-k8s-operators | grep -vE -- 'indirect|openstack-baremetal-operator|^replace' | awk '{print $$1}'); do \
+		cd ./api && go get $$dep@$(BRANCH) && cd .. ; \
+	done


### PR DESCRIPTION
The new force-bump target bumps operator and lib-common dependencies of this operator by tracking the same branch from these dependencies.

18.0-fr1 only change:

* resolve the merge conflict in Makefile due to 80771af is not in 18.0-fr1
* switched the branch target of force-bump to 18.0-fr1

Related: [OSPRH-8355](https://issues.redhat.com//browse/OSPRH-8355)
(cherry picked from commit 38113a0073ee9372a53e464ce532fefa02351558)