### PR TITLE
Enable root login when root password has been set

### DIFF
--- a/templates/openstackbaremetalset/cloudinit/userdata
+++ b/templates/openstackbaremetalset/cloudinit/userdata
@@ -8,6 +8,8 @@ users:
     sudo: ['ALL=(ALL) NOPASSWD:ALL']
     shell: /bin/bash
 {{- if (index . "NodeRootPassword") }}
+disable_root: false
+ssh_pwauth:   true
 chpasswd:
   list: |
     root:{{ .NodeRootPassword }}


### PR DESCRIPTION
By default, root login is disabled.