### PR TITLE
Remove default for optional CtlplaneNetmask

### DIFF
--- a/api/bases/baremetal.openstack.org_openstackbaremetalsets.yaml
+++ b/api/bases/baremetal.openstack.org_openstackbaremetalsets.yaml
@@ -144,7 +144,6 @@ spec:
                   to use for ctlplane network
                 type: string
               ctlplaneNetmask:
-                default: 255.255.255.0
                 description: 'CtlplaneNetmask - Netmask to use for ctlplane network
                   (TODO: acquire this is another manner?)'
                 type: string

--- a/api/v1beta1/openstackbaremetalset_types.go
+++ b/api/v1beta1/openstackbaremetalset_types.go
@@ -88,7 +88,6 @@ type OpenStackBaremetalSetSpec struct {
 	// +kubebuilder:validation:Optional
 	CtlplaneGateway string `json:"ctlplaneGateway,omitempty"`
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="255.255.255.0"
 	// CtlplaneNetmask - Netmask to use for ctlplane network (TODO: acquire this is another manner?)
 	CtlplaneNetmask string `json:"ctlplaneNetmask,omitempty"`
 	// +kubebuilder:default=openshift-machine-api

--- a/config/crd/bases/baremetal.openstack.org_openstackbaremetalsets.yaml
+++ b/config/crd/bases/baremetal.openstack.org_openstackbaremetalsets.yaml
@@ -144,7 +144,6 @@ spec:
                   to use for ctlplane network
                 type: string
               ctlplaneNetmask:
-                default: 255.255.255.0
                 description: 'CtlplaneNetmask - Netmask to use for ctlplane network
                   (TODO: acquire this is another manner?)'
                 type: string

--- a/tests/functional/openstackbaremetalset_controller_test.go
+++ b/tests/functional/openstackbaremetalset_controller_test.go
@@ -84,7 +84,6 @@ var _ = Describe("BaremetalSet Test", func() {
 				DeploymentSSHSecret:   "mysecret",
 				CtlplaneInterface:     "eth0",
 				CtlplaneGateway:       "",
-				CtlplaneNetmask:       "255.255.255.0",
 				BmhNamespace:          baremetalSetName.Namespace,
 				BmhLabelSelector:      map[string]string{"app": "openstack"},
 				HardwareReqs: baremetalv1.HardwareReqs{


### PR DESCRIPTION
Since this parameter is optional, we shouldn't set a default. This change removes the default for the param which will allow us to entirely remove the unused parameter once other projects have removed references to it.

Related: https://issues.redhat.com/browse/OSPRH-12304