### PR TITLE
Refactor webhook method to use in openstack-operator

### DIFF
--- a/api/v1beta1/openstackbaremetalset_types.go
+++ b/api/v1beta1/openstackbaremetalset_types.go
@@ -101,6 +101,9 @@ type OpenStackBaremetalSetTemplateSpec struct {
 	// +kubebuilder:default=cloud-admin
 	// CloudUser to be configured for remote access
 	CloudUserName string `json:"cloudUserName"`
+	// DomainName is the domain name that will be set on the underlying Metal3 BaremetalHosts (TODO: acquire this is another manner?)
+	// +kubebuilder:validation:Optional
+	DomainName string `json:"domainName,omitempty"`
 }
 
 // OpenStackBaremetalSetSpec defines the desired state of OpenStackBaremetalSet
@@ -114,9 +117,6 @@ type OpenStackBaremetalSetSpec struct {
 	// +kubebuilder:validation:Optional
 	// CtlplaneVlan - Vlan for ctlplane network
 	CtlplaneVlan *int `json:"ctlplaneVlan,omitempty"`
-	// DomainName is the domain name that will be set on the underlying Metal3 BaremetalHosts (TODO: acquire this is another manner?)
-	// +kubebuilder:validation:Optional
-	DomainName string `json:"domainName,omitempty"`
 	// +kubebuilder:validation:Optional
 	// BootstrapDNS - initial DNS nameserver values to set on the BaremetalHosts when they are provisioned.
 	// Note that subsequent deployment will overwrite these values

--- a/tests/functional/openstackbaremetalset_controller_test.go
+++ b/tests/functional/openstackbaremetalset_controller_test.go
@@ -93,6 +93,7 @@ var _ = Describe("BaremetalSet Test", func() {
 				},
 				PasswordSecret: nil,
 				CloudUserName:  "cloud-admin",
+				DomainName:     "",
 			}
 			spec := baremetalv1.OpenStackBaremetalSetSpec{
 				BaremetalHosts: map[string]baremetalv1.InstanceSpec{
@@ -104,7 +105,6 @@ var _ = Describe("BaremetalSet Test", func() {
 					},
 				},
 				CtlplaneGateway:                   "",
-				DomainName:                        "",
 				BootstrapDNS:                      nil,
 				DNSSearchDomains:                  nil,
 				OpenStackBaremetalSetTemplateSpec: coreSpec,


### PR DESCRIPTION
This was missed in the earlier PR. Also moves domain back to the OpenStackBaremetalSetTemplateSpec as there is no way to get it from nodeset spec.