### PR TITLE
Fix regression when assigning provision server port

### DIFF
--- a/api/v1beta1/openstackprovisionserver.go
+++ b/api/v1beta1/openstackprovisionserver.go
@@ -65,7 +65,8 @@ func AssignProvisionServerPort(
 
 		if found {
 			if existingPorts[instance.GetName()] != cur {
-				return fmt.Errorf("%v port already used by another OpeStackProvisionServer", cur)
+				// continue to use the next port in the port range.
+				continue
 			} else {
 				break
 			}


### PR DESCRIPTION
This mistakenly throws an error rather than using the next port in the port range.

Jira: https://issues.redhat.com/browse/OSPRH-12774