### PR TITLE
Add kubebuilder default for OSBMS osImage

### DIFF
--- a/api/bases/baremetal.openstack.org_openstackbaremetalsets.yaml
+++ b/api/bases/baremetal.openstack.org_openstackbaremetalsets.yaml
@@ -257,6 +257,7 @@ spec:
                   the OS qcow2 image (osImage)
                 type: string
               osImage:
+                default: edpm-hardened-uefi.qcow2
                 description: OSImage - OS qcow2 image Name
                 type: string
               passwordSecret:

--- a/api/v1beta1/openstackbaremetalset_types.go
+++ b/api/v1beta1/openstackbaremetalset_types.go
@@ -51,6 +51,7 @@ const (
 
 type OpenStackBaremetalSetTemplateSpec struct {
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=edpm-hardened-uefi.qcow2
 	// OSImage - OS qcow2 image Name
 	OSImage string `json:"osImage,omitempty"`
 	// +kubebuilder:validation:Optional

--- a/config/crd/bases/baremetal.openstack.org_openstackbaremetalsets.yaml
+++ b/config/crd/bases/baremetal.openstack.org_openstackbaremetalsets.yaml
@@ -257,6 +257,7 @@ spec:
                   the OS qcow2 image (osImage)
                 type: string
               osImage:
+                default: edpm-hardened-uefi.qcow2
                 description: OSImage - OS qcow2 image Name
                 type: string
               passwordSecret:

--- a/tests/functional/openstackbaremetalset_controller_test.go
+++ b/tests/functional/openstackbaremetalset_controller_test.go
@@ -66,7 +66,7 @@ var _ = Describe("BaremetalSet Test", func() {
 		It("should have the Spec fields initialized", func() {
 			baremetalSetInstance := GetBaremetalSet(baremetalSetName)
 			coreSpec := baremetalv1.OpenStackBaremetalSetTemplateSpec{
-				OSImage:               "",
+				OSImage:               "edpm-hardened-uefi.qcow2",
 				OSContainerImageURL:   "",
 				ApacheImageURL:        "",
 				AgentImageURL:         "",


### PR DESCRIPTION
In the course of supporting the new OpenStack operator install paradigm, service operator webhooks will be removed.  This effects this operator.  As a result, `OpenStackBaremetalSet.spec.osImage` is no longer being defaulted.  It needs to be so for provisioning to work properly.  Therefore, since we are removing the webhooks in the new install paradigm, let's add a kubebuilder default for `osImage` to handle this case.  Note that the other previously-webhook-defaulted fields are defaulted by OpenStack operator (`OpenStackDataPlaneNodeSet` controller [1]) and thus do not need kubebuilder defaults.

[1] https://github.com/openstack-k8s-operators/openstack-operator/blob/f42bc846b6ef15db7c10ae8322e1d8916b569406/pkg/dataplane/baremetal.go#L62-L70