### PR TITLE
[OSPRH-13507] Surface prov interface errors reported by agent

### DIFF
--- a/api/bases/baremetal.openstack.org_openstackprovisionservers.yaml
+++ b/api/bases/baremetal.openstack.org_openstackprovisionservers.yaml
@@ -231,6 +231,10 @@ spec:
                 description: IP of the provisioning interface on the node running
                   the ProvisionServer pod
                 type: string
+              provisionIpError:
+                description: Any error reported by the provisioning agent during provisioning
+                  IP acquisition
+                type: string
               readyCount:
                 description: ReadyCount of provision server Apache instances
                 format: int32

--- a/api/v1beta1/conditions.go
+++ b/api/v1beta1/conditions.go
@@ -72,8 +72,11 @@ const (
 	// OpenStackProvisionServerProvIntfReadyErrorMessage
 	OpenStackProvisionServerProvIntfReadyErrorMessage = "OpenStackProvisionServerProvIntf error occured %s"
 
+	// OpenStackProvisionServerProvIntfReadyRunningMessage
+	OpenStackProvisionServerProvIntfReadyRunningMessage = "OpenStackProvisionServerProvIntf acquisition in progress"
+
 	// OpenStackProvisionServerProvIntfReadyMessage
-	OpenStackProvisionServerProvIntfReadyMessage = "OpenStackProvisionServerProvIntf found"
+	OpenStackProvisionServerProvIntfReadyMessage = "OpenStackProvisionServerProvIntf found and IP acquired"
 
 	//
 	// OpenStackProvisionServerLocalImageURLReady condition messages

--- a/api/v1beta1/openstackprovisionserver_types.go
+++ b/api/v1beta1/openstackprovisionserver_types.go
@@ -96,6 +96,8 @@ type OpenStackProvisionServerStatus struct {
 	Hash map[string]string `json:"hash,omitempty"`
 	// IP of the provisioning interface on the node running the ProvisionServer pod
 	ProvisionIP string `json:"provisionIp,omitempty"`
+	// Any error reported by the provisioning agent during provisioning IP acquisition
+	ProvisionIPError string `json:"provisionIpError,omitempty"`
 	// URL of provisioning image on underlying Apache web server
 	LocalImageURL string `json:"localImageUrl,omitempty"`
 	// Filename of OSImage checksum

--- a/config/crd/bases/baremetal.openstack.org_openstackprovisionservers.yaml
+++ b/config/crd/bases/baremetal.openstack.org_openstackprovisionservers.yaml
@@ -231,6 +231,10 @@ spec:
                 description: IP of the provisioning interface on the node running
                   the ProvisionServer pod
                 type: string
+              provisionIpError:
+                description: Any error reported by the provisioning agent during provisioning
+                  IP acquisition
+                type: string
               readyCount:
                 description: ReadyCount of provision server Apache instances
                 format: int32

--- a/pkg/openstackprovisionserver/errors.go
+++ b/pkg/openstackprovisionserver/errors.go
@@ -1,0 +1,7 @@
+package openstackprovisionserver
+
+import "errors"
+
+var (
+	ErrProvisioningAgent = errors.New("provisioning agent reported error")
+)


### PR DESCRIPTION
Let's improve the logic of the provisioning agent so that it reports problems with the provisioning interface back to the cluster and surfaces them in the `OpenStackProvisionServer` resource.

Jira: https://issues.redhat.com/browse/OSPRH-13507