### PR TITLE
Reconcile for BMH delete events

### DIFF
--- a/api/v1beta1/openstackbaremetalset_webhook.go
+++ b/api/v1beta1/openstackbaremetalset_webhook.go
@@ -135,7 +135,7 @@ func (r *OpenStackBaremetalSet) ValidateUpdate(old runtime.Object) (admission.Wa
 		// operations for scaling up or down.
 		//
 		// TODO: Create a specific context here instead of passing TODO()?
-		if err := VerifyBaremetalStatusBmhRefs(context.TODO(), webhookClient, r); err != nil {
+		if err := VerifyAndSyncBaremetalStatusBmhRefs(context.TODO(), webhookClient, r); err != nil {
 			return nil, err
 		}
 

--- a/controllers/openstackbaremetalset_controller.go
+++ b/controllers/openstackbaremetalset_controller.go
@@ -208,7 +208,7 @@ func statusChangePredicate() predicate.Predicate {
 		},
 
 		DeleteFunc: func(_ event.DeleteEvent) bool {
-			return false // Ignore delete events
+			return true // Reconcile for delete events
 		},
 
 		GenericFunc: func(_ event.GenericEvent) bool {
@@ -435,7 +435,7 @@ func (r *OpenStackBaremetalSetReconciler) reconcileNormal(ctx context.Context, i
 	// If so, we cannot proceed further as we will risk placing the CR into an
 	// inconsistent state and/or introducing unbounded reconciliation thrashing.
 	//
-	err = baremetalv1.VerifyBaremetalStatusBmhRefs(ctx, helper.GetClient(), instance)
+	err = baremetalv1.VerifyAndSyncBaremetalStatusBmhRefs(ctx, helper.GetClient(), instance)
 
 	if err != nil {
 		instance.Status.Conditions.Set(condition.FalseCondition(


### PR DESCRIPTION
As one can delete BMHs with consumerRef outside the general compute scale-down method, it's better to reconcile when for instance faulty BMHs are deleted and replace the computes with a new BMHs (if available).

Users just need to recreate a deployment to deploy on those newly created nodes.

jira: https://issues.redhat.com/browse/OSPRH-13948