### PR TITLE
Don't requeue when checking for provisioning status

### DIFF
--- a/controllers/openstackbaremetalset_controller.go
+++ b/controllers/openstackbaremetalset_controller.go
@@ -500,7 +500,7 @@ func (r *OpenStackBaremetalSetReconciler) reconcileNormal(ctx context.Context, i
 				condition.RequestedReason,
 				condition.SeverityInfo,
 				baremetalv1.OpenStackBaremetalSetBmhProvisioningReadyRunningMessage))
-			return ctrl.Result{RequeueAfter: time.Second * 20}, nil
+			return ctrl.Result{}, nil
 		}
 	}
 	instance.Status.Conditions.MarkTrue(baremetalv1.OpenStackBaremetalSetBmhProvisioningReadyCondition, baremetalv1.OpenStackBaremetalSetBmhProvisioningReadyMessage)


### PR DESCRIPTION
Event will be triggerred when BMH status chnages, so we don't have to requeue explicitly.