### PR TITLE
Move ctlplaneVlan and ctlplaneGateway to InstanceSpec

### DIFF
--- a/api/bases/baremetal.openstack.org_openstackbaremetalsets.yaml
+++ b/api/bases/baremetal.openstack.org_openstackbaremetalsets.yaml
@@ -83,6 +83,13 @@ spec:
                     ctlPlaneIP:
                       description: CtlPlaneIP - Control Plane IP in CIDR notation
                       type: string
+                    ctlplaneGateway:
+                      description: 'CtlplaneGateway - IP of gateway for ctrlplane
+                        network (TODO: acquire this is another manner?)'
+                      type: string
+                    ctlplaneVlan:
+                      description: CtlplaneVlan - Vlan for ctlplane network
+                      type: integer
                     networkData:
                       description: NetworkData - Host Network Data
                       properties:

--- a/api/v1beta1/openstackbaremetalset_types.go
+++ b/api/v1beta1/openstackbaremetalset_types.go
@@ -34,6 +34,12 @@ type InstanceSpec struct {
 	// +kubebuilder:validation:Optional
 	// CtlPlaneIP - Control Plane IP in CIDR notation
 	CtlPlaneIP string `json:"ctlPlaneIP,omitempty"`
+	// CtlplaneGateway - IP of gateway for ctrlplane network (TODO: acquire this is another manner?)
+	// +kubebuilder:validation:Optional
+	CtlplaneGateway string `json:"ctlplaneGateway,omitempty"`
+	// +kubebuilder:validation:Optional
+	// CtlplaneVlan - Vlan for ctlplane network
+	CtlplaneVlan *int `json:"ctlplaneVlan,omitempty"`
 	// +kubebuilder:validation:Optional
 	// UserData - Host User Data
 	UserData *corev1.SecretReference `json:"userData,omitempty"`

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -186,6 +186,11 @@ func (in *InstanceSpec) DeepCopyInto(out *InstanceSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.CtlplaneVlan != nil {
+		in, out := &in.CtlplaneVlan, &out.CtlplaneVlan
+		*out = new(int)
+		**out = **in
+	}
 	if in.UserData != nil {
 		in, out := &in.UserData, &out.UserData
 		*out = new(v1.SecretReference)

--- a/config/crd/bases/baremetal.openstack.org_openstackbaremetalsets.yaml
+++ b/config/crd/bases/baremetal.openstack.org_openstackbaremetalsets.yaml
@@ -83,6 +83,13 @@ spec:
                     ctlPlaneIP:
                       description: CtlPlaneIP - Control Plane IP in CIDR notation
                       type: string
+                    ctlplaneGateway:
+                      description: 'CtlplaneGateway - IP of gateway for ctrlplane
+                        network (TODO: acquire this is another manner?)'
+                      type: string
+                    ctlplaneVlan:
+                      description: CtlplaneVlan - Vlan for ctlplane network
+                      type: integer
                     networkData:
                       description: NetworkData - Host Network Data
                       properties:

--- a/pkg/openstackbaremetalset/baremetalhost.go
+++ b/pkg/openstackbaremetalset/baremetalhost.go
@@ -110,11 +110,17 @@ func BaremetalHostProvision(
 		templateParameters := make(map[string]interface{})
 		templateParameters["CtlplaneIpVersion"] = CtlplaneIPVersion
 		templateParameters["CtlplaneIp"] = ipAddr
-		if instance.Spec.CtlplaneVlan != nil {
+		if instance.Spec.BaremetalHosts[hostName].CtlplaneVlan != nil {
+			templateParameters["CtlplaneVlan"] = *instance.Spec.BaremetalHosts[hostName].CtlplaneVlan
+		} else if instance.Spec.CtlplaneVlan != nil {
 			templateParameters["CtlplaneVlan"] = *instance.Spec.CtlplaneVlan
 		}
 		templateParameters["CtlplaneInterface"] = instance.Spec.CtlplaneInterface
-		templateParameters["CtlplaneGateway"] = instance.Spec.CtlplaneGateway
+		if instance.Spec.BaremetalHosts[hostName].CtlplaneGateway != "" {
+			templateParameters["CtlplaneGateway"] = instance.Spec.BaremetalHosts[hostName].CtlplaneGateway
+		} else {
+			templateParameters["CtlplaneGateway"] = instance.Spec.CtlplaneGateway
+		}
 		templateParameters["CtlplaneNetmask"] = net.IP(ipNet.Mask)
 		if len(instance.Spec.BootstrapDNS) > 0 {
 			templateParameters["CtlplaneDns"] = instance.Spec.BootstrapDNS

--- a/tests/functional/openstackbaremetalset_controller_test.go
+++ b/tests/functional/openstackbaremetalset_controller_test.go
@@ -104,7 +104,6 @@ var _ = Describe("BaremetalSet Test", func() {
 						BmhLabelSelector: nil,
 					},
 				},
-				CtlplaneGateway:                   "",
 				BootstrapDNS:                      nil,
 				DNSSearchDomains:                  nil,
 				OpenStackBaremetalSetTemplateSpec: coreSpec,


### PR DESCRIPTION
It could be different for different baremetal hosts based on the subnets they use.

jira: https://issues.redhat.com/browse/OSPRH-15221