### PR TITLE
Allow override CtlplaneInterface in InstanceSpec

### DIFF
--- a/api/bases/baremetal.openstack.org_openstackbaremetalsets.yaml
+++ b/api/bases/baremetal.openstack.org_openstackbaremetalsets.yaml
@@ -87,6 +87,10 @@ spec:
                       description: 'CtlplaneGateway - IP of gateway for ctrlplane
                         network (TODO: acquire this is another manner?)'
                       type: string
+                    ctlplaneInterface:
+                      description: CtlplaneInterface - Interface on the provisioned
+                        nodes to use for ctlplane network
+                      type: string
                     ctlplaneVlan:
                       description: CtlplaneVlan - Vlan for ctlplane network
                       type: integer

--- a/api/v1beta1/openstackbaremetalset_types.go
+++ b/api/v1beta1/openstackbaremetalset_types.go
@@ -37,6 +37,9 @@ type InstanceSpec struct {
 	// CtlplaneGateway - IP of gateway for ctrlplane network (TODO: acquire this is another manner?)
 	// +kubebuilder:validation:Optional
 	CtlplaneGateway string `json:"ctlplaneGateway,omitempty"`
+	// CtlplaneInterface - Interface on the provisioned nodes to use for ctlplane network
+	// +kubebuilder:validation:Optional
+	CtlplaneInterface string `json:"ctlplaneInterface,omitempty"`
 	// +kubebuilder:validation:Optional
 	// CtlplaneVlan - Vlan for ctlplane network
 	CtlplaneVlan *int `json:"ctlplaneVlan,omitempty"`

--- a/config/crd/bases/baremetal.openstack.org_openstackbaremetalsets.yaml
+++ b/config/crd/bases/baremetal.openstack.org_openstackbaremetalsets.yaml
@@ -87,6 +87,10 @@ spec:
                       description: 'CtlplaneGateway - IP of gateway for ctrlplane
                         network (TODO: acquire this is another manner?)'
                       type: string
+                    ctlplaneInterface:
+                      description: CtlplaneInterface - Interface on the provisioned
+                        nodes to use for ctlplane network
+                      type: string
                     ctlplaneVlan:
                       description: CtlplaneVlan - Vlan for ctlplane network
                       type: integer

--- a/pkg/openstackbaremetalset/baremetalhost.go
+++ b/pkg/openstackbaremetalset/baremetalhost.go
@@ -115,7 +115,11 @@ func BaremetalHostProvision(
 		} else if instance.Spec.CtlplaneVlan != nil {
 			templateParameters["CtlplaneVlan"] = *instance.Spec.CtlplaneVlan
 		}
-		templateParameters["CtlplaneInterface"] = instance.Spec.CtlplaneInterface
+		if instance.Spec.BaremetalHosts[hostName].CtlplaneInterface != "" {
+			templateParameters["CtlplaneInterface"] = instance.Spec.BaremetalHosts[hostName].CtlplaneInterface
+		} else {
+			templateParameters["CtlplaneInterface"] = instance.Spec.CtlplaneInterface
+		}
 		if instance.Spec.BaremetalHosts[hostName].CtlplaneGateway != "" {
 			templateParameters["CtlplaneGateway"] = instance.Spec.BaremetalHosts[hostName].CtlplaneGateway
 		} else {


### PR DESCRIPTION
Allow overriding the `CtlplaneInterface` in the `InstanceSpec`, this will allow nodesets where one or more nodes use different interfaces for the ctlplane interface.