### PR TITLE
Ensure userData and networkData secrets are in bmhNamespace

### DIFF
--- a/pkg/openstackbaremetalset/baremetalhost.go
+++ b/pkg/openstackbaremetalset/baremetalhost.go
@@ -79,7 +79,7 @@ func BaremetalHostProvision(
 
 		userDataSt := util.Template{
 			Name:               userDataSecretName,
-			Namespace:          instance.Namespace,
+			Namespace:          instance.Spec.BmhNamespace,
 			Type:               util.TemplateTypeConfig,
 			InstanceType:       instance.Kind,
 			AdditionalTemplate: map[string]string{"userData": "/openstackbaremetalset/cloudinit/userdata"},
@@ -89,7 +89,7 @@ func BaremetalHostProvision(
 		sts = append(sts, userDataSt)
 		userDataSecret = &corev1.SecretReference{
 			Name:      userDataSecretName,
-			Namespace: instance.Namespace,
+			Namespace: instance.Spec.BmhNamespace,
 		}
 
 	}
@@ -147,7 +147,7 @@ func BaremetalHostProvision(
 
 		networkDataSt := util.Template{
 			Name:               networkDataSecretName,
-			Namespace:          instance.Namespace,
+			Namespace:          instance.Spec.BmhNamespace,
 			Type:               util.TemplateTypeConfig,
 			InstanceType:       instance.Kind,
 			AdditionalTemplate: map[string]string{"networkData": "/openstackbaremetalset/cloudinit/networkdata"},
@@ -157,7 +157,7 @@ func BaremetalHostProvision(
 		sts = append(sts, networkDataSt)
 		networkDataSecret = &corev1.SecretReference{
 			Name:      networkDataSecretName,
-			Namespace: instance.Namespace,
+			Namespace: instance.Spec.BmhNamespace,
 		}
 	}
 


### PR DESCRIPTION
This is required as there is an backward incompatible change[1] introduced in baremetal-operator.

Also fixes a bug where we were not returning name validation error.

[1] https://github.com/metal3-io/baremetal-operator/pull/1930