### PR TITLE
Allow using online: true in bmh spec

### DIFF
--- a/api/v1beta1/openstackbaremetalset.go
+++ b/api/v1beta1/openstackbaremetalset.go
@@ -131,8 +131,18 @@ func VerifyBaremetalSetScaleUp(
 				mismatch = true
 			}
 
-			if baremetalHost.Spec.Online {
-				l.Info("BaremetalHost cannot be used because it is already online", "BMH", baremetalHost.ObjectMeta.Name)
+			if baremetalHost.Spec.Image != nil && baremetalHost.Spec.Image.URL != "" {
+				l.Info("BaremetalHost cannot be used because it already has an image", "BMH", baremetalHost.ObjectMeta.Name)
+				mismatch = true
+			}
+
+			if baremetalHost.Spec.ExternallyProvisioned {
+				l.Info("BaremetalHost cannot be used because it is externally provisioned", "BMH", baremetalHost.ObjectMeta.Name)
+				mismatch = true
+			}
+
+			if baremetalHost.Spec.CustomDeploy != nil {
+				l.Info("BaremetalHost cannot be used because it already has a customDeploy", "BMH", baremetalHost.ObjectMeta.Name)
 				mismatch = true
 			}
 


### PR DESCRIPTION
The Online flag indicatets wheater Metal3 should ensure the state of the host is powerd on when in a stable state.

With ironic fast-track if a host is created, and inspection is enabled the host will boot into ironic-python-agent - inspect ... then leave the node running with the agent ready for new commands - such as provision an image. When online is `false` the node will power-off after inspection, forcing another reboot to start the ironic-python-agent again.

Allowing `online: true` should result in faster deployment when inspection is enabled since it will use the fast-track mode.

I also think not allowing `online: true `this is counter intuitive, considering that Openshift examples in [docs]( https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/scalability_and_performance/managing-bare-metal-hosts) have `online: true` in examples for creating BMHs.

Adding `Image.URL` `ExternallyProvisioned` and `CustomDeploy` to ensure hosts with those set are considered a mismatch. These seem to make sense based on what blocks inspection and what is considered provisioned in metal3-io/baremetal-operator's `WasProvisioned()` and `NeedsHardwareInspection()` functions.

