### PR TITLE
Give network-manager renderer preference

### DIFF
--- a/templates/openstackbaremetalset/cloudinit/userdata
+++ b/templates/openstackbaremetalset/cloudinit/userdata
@@ -18,3 +18,5 @@ chpasswd:
 bootcmd:
   # fix BLS entries
   - set -x; if [ -e /boot/loader/entries/ffffffffffffffffffffffffffffffff-* ]; then MACHINEID=$(cat /etc/machine-id) && rename "ffffffffffffffffffffffffffffffff" "$MACHINEID" /boot/loader/entries/ffffffffffffffffffffffffffffffff-* ; fi
+network:
+  renderers: ['netplan', 'network-manager', 'eni', 'sysconfig']


### PR DESCRIPTION
Now that we use nmstate provider to configure networks by default and  allow NetworkManager to update dns settings during bootstrap, we should give `network-manager` renderer priority over sysconfig.