### PR TITLE
[networkdata] Move nameservers/domains at network level

### DIFF
--- a/templates/openstackbaremetalset/cloudinit/networkdata
+++ b/templates/openstackbaremetalset/cloudinit/networkdata
@@ -28,14 +28,12 @@ networks:
     gateway: {{ .CtlplaneGateway }}
 {{- end }}
 {{- if not (eq (len .CtlplaneDns) 0) }}
-services:
-- type: dns-nameserver
-  address:
+  dns_nameservers:
     {{- range $value := .CtlplaneDns }}
     - {{ $value }}
     {{- end }}
   {{- if not (eq (len .CtlplaneDnsSearch) 0) }}
-  search:
+  dns_search:
     {{- range $value := .CtlplaneDnsSearch }}
     - {{ $value }}
     {{- end }}


### PR DESCRIPTION
With current config cloud-init was updating /etc/resolv.conf and that get's wiped off with NetworkManager reload/restart. Instead we should configure it via network config like sysconfig/network-manager etc.

Related-Issue: https://issues.redhat.com/browse/OSPRH-19018