### PR TITLE
[OSPRH-19336] Remove deprecated Kustomize fields in config dir

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -6,17 +6,17 @@ resources:
 - bases/baremetal.openstack.org_openstackbaremetalsets.yaml
 #+kubebuilder:scaffold:crdkustomizeresource
 
-patchesStrategicMerge:
+patches:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
-#- patches/webhook_in_openstackprovisionservers.yaml
-#- patches/webhook_in_openstackbaremetalsets.yaml
+#- path: patches/webhook_in_openstackprovisionservers.yaml
+#- path: patches/webhook_in_openstackbaremetalsets.yaml
 #+kubebuilder:scaffold:crdkustomizewebhookpatch
 
 # [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
-#- patches/cainjection_in_openstackprovisionservers.yaml
-#- patches/cainjection_in_openstackbaremetalsets.yaml
+#- path: patches/cainjection_in_openstackprovisionservers.yaml
+#- path: patches/cainjection_in_openstackbaremetalsets.yaml
 #+kubebuilder:scaffold:crdkustomizecainjectionpatch
 
 # the following config is for teaching kustomize how to do kustomization for CRDs.

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -9,10 +9,13 @@ namespace: openstack-baremetal-operator-system
 namePrefix: openstack-baremetal-operator-
 
 # Labels to add to all resources and selectors.
-#commonLabels:
-#  someName: someValue
+#labels:
+#- includeSelectors: true
+#  includeTemplates: true
+#  pairs:
+#    someName: someValue
 
-bases:
+resources:
 - ../crd
 - ../rbac
 - ../manager
@@ -24,25 +27,26 @@ bases:
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
 
-patchesStrategicMerge:
+patches:
 # Protect the /metrics endpoint by putting it behind auth.
 # If you want your controller-manager to expose the /metrics
 # endpoint w/o any authn/z, please comment the following line.
-- manager_auth_proxy_patch.yaml
+- path: manager_auth_proxy_patch.yaml
 
 
 
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
-- manager_webhook_patch.yaml
+- path: manager_webhook_patch.yaml
 
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
 # Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
 # 'CERTMANAGER' needs to be enabled to use ca injection
-- webhookcainjection_patch.yaml
+- path: mutatingwebhookcainjection_patch.yaml
+- path: validatingwebhookcainjection_patch.yaml
 
 # Injects our custom images (ENV variable settings)
-- manager_default_images.yaml
+- path: manager_default_images.yaml
 
 # the following config is for teaching kustomize how to do var substitution
 vars:

--- a/config/default/mutatingwebhookcainjection_patch.yaml
+++ b/config/default/mutatingwebhookcainjection_patch.yaml
@@ -1,0 +1,15 @@
+# This patch add annotation to admission webhook config and
+# the variables $(CERTIFICATE_NAMESPACE) and $(CERTIFICATE_NAME) will be substituted by kustomize.
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  labels:
+    app.kubernetes.io/name: mutatingwebhookconfiguration
+    app.kubernetes.io/instance: mutating-webhook-configuration
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/created-by: openstack-baremetal-operator
+    app.kubernetes.io/part-of: openstack-baremetal-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: mutating-webhook-configuration
+  annotations:
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)

--- a/config/default/validatingwebhookcainjection_patch.yaml
+++ b/config/default/validatingwebhookcainjection_patch.yaml
@@ -1,20 +1,6 @@
 # This patch add annotation to admission webhook config and
 # the variables $(CERTIFICATE_NAMESPACE) and $(CERTIFICATE_NAME) will be substituted by kustomize.
 apiVersion: admissionregistration.k8s.io/v1
-kind: MutatingWebhookConfiguration
-metadata:
-  labels:
-    app.kubernetes.io/name: mutatingwebhookconfiguration
-    app.kubernetes.io/instance: mutating-webhook-configuration
-    app.kubernetes.io/component: webhook
-    app.kubernetes.io/created-by: openstack-baremetal-operator
-    app.kubernetes.io/part-of: openstack-baremetal-operator
-    app.kubernetes.io/managed-by: kustomize
-  name: mutating-webhook-configuration
-  annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
----
-apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   labels:

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -9,7 +9,7 @@ resources:
 # [WEBHOOK] To enable webhooks, uncomment all the sections with [WEBHOOK] prefix.
 # Do NOT uncomment sections with prefix [CERTMANAGER], as OLM does not support cert-manager.
 # These patches remove the unnecessary "cert" volume and its manager container volumeMount.
-#patchesJson6902:
+#patches:
 #- target:
 #    group: apps
 #    version: v1

--- a/config/scorecard/kustomization.yaml
+++ b/config/scorecard/kustomization.yaml
@@ -1,6 +1,6 @@
 resources:
 - bases/config.yaml
-patchesJson6902:
+patches:
 - path: patches/basic.config.yaml
   target:
     group: scorecard.operatorframework.io
@@ -13,4 +13,4 @@ patchesJson6902:
     version: v1alpha3
     kind: Configuration
     name: config
-#+kubebuilder:scaffold:patchesJson6902
+#+kubebuilder:scaffold:patches


### PR DESCRIPTION
Update all deprecated Kustomize fields to their modern equivalents across the config directory to ensure compatibility with Kustomize v5.3+ and future versions.

Changes made:

config/default/kustomization.yaml:
- Replace 'bases:' with 'resources:'
- Replace 'patchesStrategicMerge:' with 'patches:'
- Convert patch entries to use 'path:' format
- Update commented 'commonLabels:' to modern 'labels:' syntax with includeSelectors/includeTemplates structure
- Split webhook CA injection patch into separate mutating and validating patches for compatibility with modern Kustomize

config/crd/kustomization.yaml:
- Replace 'patchesStrategicMerge:' with 'patches:'
- Update commented patch entries to use 'path:' format for both webhook and cainjection patches

config/manifests/kustomization.yaml:
- Replace commented '#patchesJson6902:' with '#patches:'

config/scorecard/kustomization.yaml:
- Replace 'patchesJson6902:' with 'patches:'
- Update kubebuilder scaffold comment from 'patchesJson6902' to 'patches'

config/default/mutatingwebhookcainjection_patch.yaml:
- New file: separate mutating webhook configuration for CA injection

config/default/validatingwebhookcainjection_patch.yaml:
- Renamed from webhookcainjection_patch.yaml: separate validating webhook configuration for CA injection

These changes eliminate deprecation warnings and align with the modern Kustomize field syntax while maintaining full backward compatibility. The webhook configuration split ensures certificate injection works properly with the modernized Kustomize patches field.

Jira: https://issues.redhat.com/browse/OSPRH-19336

Co-authored-by: Claude [claude@anthropic.com](mailto:claude@anthropic.com)