### PR TITLE
Revert "Bump operator-lint"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -376,7 +376,7 @@ tidy: ## Run go mod tidy on every mod file in the repo
 
 .PHONY: operator-lint
 operator-lint: gowork ## Runs operator-lint
-	GOBIN=$(LOCALBIN) go install github.com/gibizer/operator-lint@v0.5.0
+	GOBIN=$(LOCALBIN) go install github.com/gibizer/operator-lint@v0.1.0
 	go vet -vettool=$(LOCALBIN)/operator-lint ./... ./api/...
 
 # Used for webhook testing

--- a/api/v1beta1/openstackbaremetalset_types.go
+++ b/api/v1beta1/openstackbaremetalset_types.go
@@ -62,7 +62,7 @@ type OpenStackBaremetalSetTemplateSpec struct {
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=edpm-hardened-uefi.qcow2
 	// OSImage - OS qcow2 image Name
-	OSImage string `json:"osImage"`
+	OSImage string `json:"osImage,omitempty"`
 	// +kubebuilder:validation:Optional
 	// OSContainerImageURL - Container image URL for init with the OS qcow2 image (osImage)
 	OSContainerImageURL string `json:"osContainerImageUrl,omitempty"`
@@ -76,7 +76,7 @@ type OpenStackBaremetalSetTemplateSpec struct {
 	// during provisioning and deprovisioning.
 	// +kubebuilder:default=metadata
 	// +kubebuilder:validation:Optional
-	AutomatedCleaningMode AutomatedCleaningMode `json:"automatedCleaningMode"`
+	AutomatedCleaningMode AutomatedCleaningMode `json:"automatedCleaningMode,omitempty"`
 	// ProvisionServerName - Optional. Existing OpenStackProvisionServer to use, else one would be created.
 	// +kubebuilder:validation:Optional
 	ProvisionServerName string `json:"provisionServerName,omitempty"`
@@ -93,7 +93,7 @@ type OpenStackBaremetalSetTemplateSpec struct {
 	// +kubebuilder:default=openshift-machine-api
 	// +kubebuilder:validation:Optional
 	// BmhNamespace Namespace to look for BaremetalHosts(default: openshift-machine-api)
-	BmhNamespace string `json:"bmhNamespace"`
+	BmhNamespace string `json:"bmhNamespace,omitempty"`
 	// +kubebuilder:validation:Optional
 	// BmhLabelSelector allows for a sub-selection of BaremetalHosts based on arbitrary labels
 	BmhLabelSelector map[string]string `json:"bmhLabelSelector,omitempty"`


### PR DESCRIPTION
This reverts commit 4fdb30abf427dda6f3de28a898154162fd456364.

This seems to be causing functional test failures in openstack-operator:

OpenStackDataPlaneNodeSet.dataplane.openstack.org "ab1ba43d-50e8-463c-9764-3" is invalid: spec.baremetalSetTemplate.automatedCleaningMode: Unsupported value: "": supported values: "metadata", "disabled"