### PR TITLE
Set golang to 1.24.4 and remove github.com/Venafi/vcert/v4 pin

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/openstack-k8s-operators/openstack-baremetal-operator/api
 
-go 1.24
+go 1.24.4
 
 require (
 	github.com/go-logr/logr v1.4.3

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openstack-k8s-operators/openstack-baremetal-operator
 
-go 1.24
+go 1.24.4
 
 require (
 	github.com/blang/semver v3.5.1+incompatible
@@ -93,10 +93,6 @@ require (
 )
 
 replace github.com/openstack-k8s-operators/openstack-baremetal-operator/api => ./api
-
-// needed to to cert-manager v1.11.4 see https://github.com/cert-manager/cert-manager/blob/v1.11.4/go.mod#L263C1-L264C104
-// remove this once we bump to cert-manager v1.12.x
-replace github.com/Venafi/vcert/v4 => github.com/jetstack/vcert/v4 v4.9.6-0.20230519122548-219f317ae107 //allow-merging
 
 // mschuppert: map to latest commit from release-4.18 tag
 // must consistent within modules and service operators


### PR DESCRIPTION
Like with the operators, set golang to 1.24.4.

Also removes github.com/Venafi/vcert/v4 pinning, since we are now on later cert-manager version.