### PR TITLE
[imagePullPolicy] Switch imagePullPolicy from Always to IfNotPresent

### DIFF
--- a/internal/openstackprovisionserver/deployment.go
+++ b/internal/openstackprovisionserver/deployment.go
@@ -107,7 +107,7 @@ func Deployment(
 			Name:            "osp-provision-ip-discovery-agent",
 			Command:         []string{"/openstack-baremetal-agent", "provision-ip-discovery"},
 			Image:           instance.Spec.AgentImageURL,
-			ImagePullPolicy: corev1.PullAlways,
+			ImagePullPolicy: corev1.PullIfNotPresent,
 			Env: []corev1.EnvVar{
 				{
 					Name:  "PROV_INTF",


### PR DESCRIPTION
Use `PullIfNotPresent` instead of `PullAlways` for container image pull policy to avoid unnecessary image pulls when the image already exists locally.

Jira: https://redhat.atlassian.net/browse/OSPRH-28872