### PR TITLE
[b/r] Add restore labels to OSBMS and OSProvServer CRDs

### DIFF
--- a/api/bases/baremetal.openstack.org_openstackbaremetalsets.yaml
+++ b/api/bases/baremetal.openstack.org_openstackbaremetalsets.yaml
@@ -4,6 +4,10 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
+  labels:
+    backup.openstack.org/category: dataplane
+    backup.openstack.org/restore: "true"
+    backup.openstack.org/restore-order: "55"
   name: openstackbaremetalsets.baremetal.openstack.org
 spec:
   group: baremetal.openstack.org

--- a/api/bases/baremetal.openstack.org_openstackprovisionservers.yaml
+++ b/api/bases/baremetal.openstack.org_openstackprovisionservers.yaml
@@ -4,6 +4,10 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
+  labels:
+    backup.openstack.org/category: dataplane
+    backup.openstack.org/restore: "true"
+    backup.openstack.org/restore-order: "55"
   name: openstackprovisionservers.baremetal.openstack.org
 spec:
   group: baremetal.openstack.org

--- a/api/v1beta1/openstackbaremetalset_types.go
+++ b/api/v1beta1/openstackbaremetalset_types.go
@@ -186,6 +186,9 @@ type OpenStackBaremetalSetStatus struct {
 // +operator-sdk:csv:customresourcedefinitions:displayName="OpenStack BaremetalSet"
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.conditions[0].status",description="Status"
 // +kubebuilder:printcolumn:name="Message",type="string",JSONPath=".status.conditions[0].message",description="Message"
+// +kubebuilder:metadata:labels=backup.openstack.org/restore=true
+// +kubebuilder:metadata:labels=backup.openstack.org/category=dataplane
+// +kubebuilder:metadata:labels=backup.openstack.org/restore-order=55
 
 // OpenStackBaremetalSet is the Schema for the openstackbaremetalsets API
 type OpenStackBaremetalSet struct {

--- a/api/v1beta1/openstackprovisionserver_types.go
+++ b/api/v1beta1/openstackprovisionserver_types.go
@@ -119,6 +119,9 @@ func (instance *OpenStackProvisionServer) IsReady() bool {
 // +operator-sdk:csv:customresourcedefinitions:displayName="OpenStackProvisionServer"
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.conditions[0].status",description="Status"
 // +kubebuilder:printcolumn:name="Message",type="string",JSONPath=".status.conditions[0].message",description="Message"
+// +kubebuilder:metadata:labels=backup.openstack.org/restore=true
+// +kubebuilder:metadata:labels=backup.openstack.org/category=dataplane
+// +kubebuilder:metadata:labels=backup.openstack.org/restore-order=55
 
 // OpenStackProvisionServer used to serve custom images for baremetal provisioning with Metal3
 type OpenStackProvisionServer struct {

--- a/config/crd/bases/baremetal.openstack.org_openstackbaremetalsets.yaml
+++ b/config/crd/bases/baremetal.openstack.org_openstackbaremetalsets.yaml
@@ -4,6 +4,10 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
+  labels:
+    backup.openstack.org/category: dataplane
+    backup.openstack.org/restore: "true"
+    backup.openstack.org/restore-order: "55"
   name: openstackbaremetalsets.baremetal.openstack.org
 spec:
   group: baremetal.openstack.org

--- a/config/crd/bases/baremetal.openstack.org_openstackprovisionservers.yaml
+++ b/config/crd/bases/baremetal.openstack.org_openstackprovisionservers.yaml
@@ -4,6 +4,10 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
+  labels:
+    backup.openstack.org/category: dataplane
+    backup.openstack.org/restore: "true"
+    backup.openstack.org/restore-order: "55"
   name: openstackprovisionservers.baremetal.openstack.org
 spec:
   group: baremetal.openstack.org


### PR DESCRIPTION
We will be defining the restore order for `OpenStackBaremetalSet` and `OpenStackProvisionServer` as `55` in our docs [1].  That should be reflected in the CRDs themselves.

Jira: https://redhat.atlassian.net/browse/OSPRH-30122

[1] https://github.com/openstack-k8s-operators/dev-docs/tree/main/backup-restore