### PR TITLE
[b/r] Add skip-webhook-validation annotation for OpenStackBaremetalSet

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/go-playground/validator/v10 v10.30.1
 	github.com/metal3-io/baremetal-operator/apis v0.9.3
 	github.com/onsi/ginkgo/v2 v2.28.2
-	github.com/onsi/gomega v1.40.0
-	github.com/openstack-k8s-operators/lib-common/modules/common v0.6.1-0.20260515134210-2e2a0d06648c
+	github.com/onsi/gomega v1.41.0
+	github.com/openstack-k8s-operators/lib-common/modules/common v0.6.1-0.20260610101308-d3778a549c89
 	k8s.io/api v0.31.14
 	k8s.io/apimachinery v0.31.14
 	sigs.k8s.io/controller-runtime v0.19.7

--- a/api/go.sum
+++ b/api/go.sum
@@ -105,10 +105,10 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/onsi/ginkgo/v2 v2.28.2 h1:DTrMfpqxiNUyQ3Y0zhn1n3cOO2euFgQPYIpkWwxVFps=
 github.com/onsi/ginkgo/v2 v2.28.2/go.mod h1:CLtbVInNckU3/+gC8LzkGUb9oF+e8W8TdUsxPwvdOgE=
-github.com/onsi/gomega v1.40.0 h1:Vtol0e1MghCD2ZVIilPDIg44XSL9l2QAn8ZNaljWcJc=
-github.com/onsi/gomega v1.40.0/go.mod h1:M/Uqpu/8qTjtzCLUA2zJHX9Iilrau25x1PdoSRbWh5A=
-github.com/openstack-k8s-operators/lib-common/modules/common v0.6.1-0.20260515134210-2e2a0d06648c h1:tTESojEnTyj5EZ1IlHiTncHqN6Az7iWLBd7sbMDSsEY=
-github.com/openstack-k8s-operators/lib-common/modules/common v0.6.1-0.20260515134210-2e2a0d06648c/go.mod h1:aIuG6lx3aS0vnXweRNdR/Q0SlfOsLIo0OzrqKK7C6xs=
+github.com/onsi/gomega v1.41.0 h1:OwKp4pXNgVxf6sCplzYo794OFNuoL2q2SBMU5NSWOjA=
+github.com/onsi/gomega v1.41.0/go.mod h1:M/Uqpu/8qTjtzCLUA2zJHX9Iilrau25x1PdoSRbWh5A=
+github.com/openstack-k8s-operators/lib-common/modules/common v0.6.1-0.20260610101308-d3778a549c89 h1:+tWqTXuBAKW4BLfegP0HvtMsE9KK8tX4lw76gaW+oeA=
+github.com/openstack-k8s-operators/lib-common/modules/common v0.6.1-0.20260610101308-d3778a549c89/go.mod h1:JC04T5G4E/he5ukonV1oCqa0QzFkLv761VbLruVghJM=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/go.mod
+++ b/go.mod
@@ -9,8 +9,8 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/metal3-io/baremetal-operator/apis v0.9.3
 	github.com/onsi/ginkgo/v2 v2.28.2
-	github.com/onsi/gomega v1.40.0
-	github.com/openstack-k8s-operators/lib-common/modules/common v0.6.1-0.20260515134210-2e2a0d06648c
+	github.com/onsi/gomega v1.41.0
+	github.com/openstack-k8s-operators/lib-common/modules/common v0.6.1-0.20260610101308-d3778a549c89
 	github.com/openstack-k8s-operators/openstack-baremetal-operator/api v0.0.0-00010101000000-000000000000
 	github.com/spf13/cobra v1.10.2
 	k8s.io/api v0.31.14

--- a/go.sum
+++ b/go.sum
@@ -131,12 +131,12 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/onsi/ginkgo/v2 v2.28.2 h1:DTrMfpqxiNUyQ3Y0zhn1n3cOO2euFgQPYIpkWwxVFps=
 github.com/onsi/ginkgo/v2 v2.28.2/go.mod h1:CLtbVInNckU3/+gC8LzkGUb9oF+e8W8TdUsxPwvdOgE=
-github.com/onsi/gomega v1.40.0 h1:Vtol0e1MghCD2ZVIilPDIg44XSL9l2QAn8ZNaljWcJc=
-github.com/onsi/gomega v1.40.0/go.mod h1:M/Uqpu/8qTjtzCLUA2zJHX9Iilrau25x1PdoSRbWh5A=
+github.com/onsi/gomega v1.41.0 h1:OwKp4pXNgVxf6sCplzYo794OFNuoL2q2SBMU5NSWOjA=
+github.com/onsi/gomega v1.41.0/go.mod h1:M/Uqpu/8qTjtzCLUA2zJHX9Iilrau25x1PdoSRbWh5A=
 github.com/openshift/api v0.0.0-20250711200046-c86d80652a9e h1:E1OdwSpqWuDPCedyUt0GEdoAE+r5TXy7YS21yNEo+2U=
 github.com/openshift/api v0.0.0-20250711200046-c86d80652a9e/go.mod h1:Shkl4HanLwDiiBzakv+con/aMGnVE2MAGvoKp5oyYUo=
-github.com/openstack-k8s-operators/lib-common/modules/common v0.6.1-0.20260515134210-2e2a0d06648c h1:tTESojEnTyj5EZ1IlHiTncHqN6Az7iWLBd7sbMDSsEY=
-github.com/openstack-k8s-operators/lib-common/modules/common v0.6.1-0.20260515134210-2e2a0d06648c/go.mod h1:aIuG6lx3aS0vnXweRNdR/Q0SlfOsLIo0OzrqKK7C6xs=
+github.com/openstack-k8s-operators/lib-common/modules/common v0.6.1-0.20260610101308-d3778a549c89 h1:+tWqTXuBAKW4BLfegP0HvtMsE9KK8tX4lw76gaW+oeA=
+github.com/openstack-k8s-operators/lib-common/modules/common v0.6.1-0.20260610101308-d3778a549c89/go.mod h1:JC04T5G4E/he5ukonV1oCqa0QzFkLv761VbLruVghJM=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/internal/webhook/v1beta1/openstackbaremetalset_webhook.go
+++ b/internal/webhook/v1beta1/openstackbaremetalset_webhook.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
+	"github.com/openstack-k8s-operators/lib-common/modules/common/annotations"
 	baremetalv1beta1 "github.com/openstack-k8s-operators/openstack-baremetal-operator/api/v1beta1"
 )
 
@@ -35,6 +36,9 @@ var (
 	// ErrInvalidOpenStackBaremetalSetType is returned when the object is not an OpenStackBaremetalSet
 	ErrInvalidOpenStackBaremetalSetType = errors.New("expected an OpenStackBaremetalSet object")
 )
+
+const skipValidationWarning = "webhook validation is being skipped due to the " +
+	annotations.SkipValidationAnnotation + " annotation; remove it when no longer needed"
 
 // nolint:unused
 // log is for logging in this package.
@@ -104,6 +108,11 @@ func (v *OpenStackBaremetalSetCustomValidator) ValidateCreate(_ context.Context,
 	}
 	openstackbaremetalsetlog.Info("Validation for OpenStackBaremetalSet upon creation", "name", openstackbaremetalset.GetName())
 
+	if annotations.SkipValidation(openstackbaremetalset) {
+		openstackbaremetalsetlog.Info("Skipping webhook validation", "name", openstackbaremetalset.GetName())
+		return admission.Warnings{skipValidationWarning}, nil
+	}
+
 	// Call the validation function from api/v1beta1
 	return openstackbaremetalset.ValidateCreate()
 }
@@ -116,6 +125,11 @@ func (v *OpenStackBaremetalSetCustomValidator) ValidateUpdate(_ context.Context,
 	}
 	openstackbaremetalsetlog.Info("Validation for OpenStackBaremetalSet upon update", "name", openstackbaremetalset.GetName())
 
+	if annotations.SkipValidation(openstackbaremetalset) {
+		openstackbaremetalsetlog.Info("Skipping webhook validation", "name", openstackbaremetalset.GetName())
+		return admission.Warnings{skipValidationWarning}, nil
+	}
+
 	// Call the validation function from api/v1beta1
 	return openstackbaremetalset.ValidateUpdate(oldObj)
 }
@@ -127,6 +141,11 @@ func (v *OpenStackBaremetalSetCustomValidator) ValidateDelete(_ context.Context,
 		return nil, fmt.Errorf("%w but got %T", ErrInvalidOpenStackBaremetalSetType, obj)
 	}
 	openstackbaremetalsetlog.Info("Validation for OpenStackBaremetalSet upon deletion", "name", openstackbaremetalset.GetName())
+
+	if annotations.SkipValidation(openstackbaremetalset) {
+		openstackbaremetalsetlog.Info("Skipping webhook validation", "name", openstackbaremetalset.GetName())
+		return admission.Warnings{skipValidationWarning}, nil
+	}
 
 	// Call the validation function from api/v1beta1
 	return openstackbaremetalset.ValidateDelete()

--- a/tests/functional/openstackbaremetalset_webhook_test.go
+++ b/tests/functional/openstackbaremetalset_webhook_test.go
@@ -11,6 +11,10 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 
+	"github.com/openstack-k8s-operators/lib-common/modules/common/annotations"
+	baremetalv1 "github.com/openstack-k8s-operators/openstack-baremetal-operator/api/v1beta1"
+	webhookv1beta1 "github.com/openstack-k8s-operators/openstack-baremetal-operator/internal/webhook/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
@@ -148,6 +152,58 @@ var _ = Describe("OpenStackBaremetalSet Webhook", func() {
 				ContainSubstring(
 					"unable to find 2 requested BaremetalHosts"),
 			)
+		})
+	})
+
+	When("When creating BaremetalSet with skip webhook validation annotation", func() {
+		BeforeEach(func() {
+			DeferCleanup(th.DeleteInstance, CreateBaremetalHost(bmhName))
+			bmh := GetBaremetalHost(bmhName)
+			Eventually(func(g Gomega) {
+				bmh.Status.Provisioning.State = metal3v1.StateAvailable
+				g.Expect(th.K8sClient.Status().Update(th.Ctx, bmh)).To(Succeed())
+			}, th.Timeout, th.Interval).Should(Succeed())
+		})
+
+		It("It should not fail even with insufficient BMHs when annotation is set", func() {
+			spec := TwoNodeBaremetalSetSpec(baremetalSetName.Namespace)
+			object := DefaultBaremetalSetTemplate(baremetalSetName, spec)
+			metadata := object["metadata"].(map[string]any)
+			metadata["annotations"] = map[string]any{
+				annotations.SkipValidationAnnotation: "",
+			}
+			unstructuredObj := &unstructured.Unstructured{Object: object}
+			_, err := controllerutil.CreateOrPatch(
+				th.Ctx, th.K8sClient, unstructuredObj, func() error { return nil })
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+
+		It("should return a warning when skip-validation annotation is set", func() {
+			validator := &webhookv1beta1.OpenStackBaremetalSetCustomValidator{}
+			obj := &baremetalv1.OpenStackBaremetalSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      baremetalSetName.Name,
+					Namespace: baremetalSetName.Namespace,
+					Annotations: map[string]string{
+						annotations.SkipValidationAnnotation: "",
+					},
+				},
+			}
+
+			warnings, err := validator.ValidateCreate(th.Ctx, obj)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(warnings).To(HaveLen(1))
+			Expect(warnings[0]).To(ContainSubstring(annotations.SkipValidationAnnotation))
+
+			warnings, err = validator.ValidateUpdate(th.Ctx, obj, obj)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(warnings).To(HaveLen(1))
+			Expect(warnings[0]).To(ContainSubstring(annotations.SkipValidationAnnotation))
+
+			warnings, err = validator.ValidateDelete(th.Ctx, obj)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(warnings).To(HaveLen(1))
+			Expect(warnings[0]).To(ContainSubstring(annotations.SkipValidationAnnotation))
 		})
 	})
 


### PR DESCRIPTION
Allow webhook validation to be bypassed by annotating an OpenStackBaremetalSet resource with
"baremetal.openstack.org/skip-webhook-validation". When present, the ValidateCreate, ValidateUpdate, and ValidateDelete webhooks return early without running the standard checks. This is useful for backup/restore operations where the normal BMH availability constraints need to be side-stepped.

Jira: [OSPRH-29980](https://redhat.atlassian.net/browse/OSPRH-29980)

Co-authored-by: Cursor Agent <cursor@cursor.com>

Depends-On: https://github.com/openstack-k8s-operators/openstack-baremetal-operator/pull/401