### PR TITLE
Fix ProvisionServer port exhaustion in envtest functional tests

### DIFF
--- a/tests/functional/openstackprovisionserver_webhook_test.go
+++ b/tests/functional/openstackprovisionserver_webhook_test.go
@@ -46,19 +46,7 @@ var _ = Describe("OpenStackProvisionServer Webhook", func() {
 				"apacheImageUrl":      "registry.redhat.io/ubi9/httpd-24:latest",
 				"agentImageUrl":       "quay.io/openstack-k8s-operators/openstack-baremetal-operator-agent:latest",
 			}
-			raw := map[string]interface{}{
-				"apiVersion": "baremetal.openstack.org/v1beta1",
-				"kind":       "OpenStackProvisionServer",
-				"metadata": map[string]interface{}{
-					"name":      provisionServerName.Name,
-					"namespace": provisionServerName.Namespace,
-				},
-				"spec": spec,
-			}
-			unstructuredObj := &unstructured.Unstructured{Object: raw}
-			_, err := controllerutil.CreateOrPatch(
-				th.Ctx, th.K8sClient, unstructuredObj, func() error { return nil })
-			Expect(err).ShouldNot(HaveOccurred())
+			DeferCleanup(th.DeleteInstance, CreateProvisionServer(provisionServerName, spec))
 		})
 	})
 
@@ -195,19 +183,7 @@ var _ = Describe("OpenStackProvisionServer Webhook", func() {
 				"apacheImageUrl":      "registry.redhat.io/ubi9/httpd-24:latest",
 				"agentImageUrl":       "quay.io/openstack-k8s-operators/openstack-baremetal-operator-agent:latest",
 			}
-			raw := map[string]interface{}{
-				"apiVersion": "baremetal.openstack.org/v1beta1",
-				"kind":       "OpenStackProvisionServer",
-				"metadata": map[string]interface{}{
-					"name":      provisionServer2Name.Name,
-					"namespace": provisionServer2Name.Namespace,
-				},
-				"spec": spec,
-			}
-			unstructuredObj := &unstructured.Unstructured{Object: raw}
-			_, err := controllerutil.CreateOrPatch(
-				th.Ctx, th.K8sClient, unstructuredObj, func() error { return nil })
-			Expect(err).ShouldNot(HaveOccurred())
+			DeferCleanup(th.DeleteInstance, CreateProvisionServer(provisionServer2Name, spec))
 		})
 	})
 

--- a/tests/functional/suit_test.go
+++ b/tests/functional/suit_test.go
@@ -200,6 +200,20 @@ var _ = BeforeEach(func() {
 	// We still request the delete of the Namespace to properly cleanup if
 	// we run the test in an existing cluster.
 	DeferCleanup(th.DeleteNamespace, namespace)
+
+	// Explicitly delete all OpenStackProvisionServer resources after each
+	// spec. envtest does not run the Kubernetes garbage collector, so
+	// ProvisionServers created as owned children of BaremetalSets are not
+	// cascade-deleted when the parent is removed. Without this cleanup,
+	// ports in the 6190-6210 range accumulate across specs until exhausted.
+	DeferCleanup(func() {
+		provServerList := &baremetalv1.OpenStackProvisionServerList{}
+		if err := k8sClient.List(ctx, provServerList); err == nil {
+			for i := range provServerList.Items {
+				k8sClient.Delete(ctx, &provServerList.Items[i]) //nolint:errcheck,gosec
+			}
+		}
+	})
 })
 
 var _ = AfterSuite(func() {


### PR DESCRIPTION
The functional tests were exhausting the OpenStackProvisionServer port range (6190-6210) when running with parallel Ginkgo processes. envtest does not run the Kubernetes garbage collector, so ProvisionServers created as owned children of BaremetalSets were never cascade-deleted when the parent was removed via DeferCleanup. Additionally, two webhook tests created ProvisionServer resources without any cleanup. These leaked resources accumulated across specs, consuming all 21 available ports and causing later tests to fail.

Add a global DeferCleanup in the suite BeforeEach that explicitly deletes all OpenStackProvisionServer resources after each spec, and fix the webhook tests to properly clean up their resources.

Closes: [OSPRH-30444](https://redhat.atlassian.net/browse/OSPRH-30444)

Co-authored-by: Claude <noreply@anthropic.com>
Co-authored-by: Cursor <cursoragent@cursor.com>