### PR TITLE
WIP Add bootc passthrough baremetal CI job

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -12,6 +12,15 @@
 - job:
     name: openstack-baremetal-operator-crc-podified-edpm-baremetal
     parent: cifmw-crc-podified-edpm-baremetal
+
+- job:
+    name: openstack-baremetal-operator-crc-podified-edpm-baremetal-bootc
+    parent: cifmw-crc-podified-edpm-baremetal-bootc
+    vars:
+      cifmw_update_containers_edpm_image_url: quay.io/openstack-k8s-operators/edpm-bootc:latest
+      cifmw_install_yamls_vars:
+        BAREMETAL_OS_IMG_TYPE: PassThrough
+
 - job:
     name: openstack-baremetal-operator-edpm-baremetal-minor-update
     parent: cifmw-crc-podified-edpm-baremetal-minor-update

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -9,6 +9,9 @@
         - openstack-baremetal-operator-crc-podified-edpm-baremetal:
             dependencies:
               - openstack-baremetal-operator-content-provider
+        - openstack-baremetal-operator-crc-podified-edpm-baremetal-bootc:
+            dependencies:
+              - openstack-baremetal-operator-content-provider
         - openstack-baremetal-operator-edpm-baremetal-minor-update:
             dependencies:
               - openstack-baremetal-operator-content-provider


### PR DESCRIPTION
Add a bootc EDPM baremetal job variant that reuses the normal content provider while switching the deployment to PassThrough with the direct bootc image.

Depends-On: https://github.com/openstack-k8s-operators/install_yamls/pull/1149