### PR TITLE
Remove deprecated webhook.Defaulter/Validator interface assertions

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -21,7 +21,6 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emicklei/go-restful/v3 v3.12.1 // indirect
 	github.com/evanphx/json-patch/v5 v5.9.0 // indirect
-	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.12 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect

--- a/api/go.sum
+++ b/api/go.sum
@@ -14,8 +14,6 @@ github.com/evanphx/json-patch v5.9.0+incompatible h1:fBXyNpNMuTTDdquAq/uisOr2lSh
 github.com/evanphx/json-patch v5.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.9.0 h1:kcBlZQbplgElYIlo/n1hJbls2z/1awpXxpRi0/FOJfg=
 github.com/evanphx/json-patch/v5 v5.9.0/go.mod h1:VNkHZ/282BpEyt/tObQO8s5CMPmYYq14uClGH4abBuQ=
-github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
-github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/fxamacker/cbor/v2 v2.7.0 h1:iM5WgngdRBanHcxugY4JySA0nk1wZorNOpTgCMedv5E=
 github.com/fxamacker/cbor/v2 v2.7.0/go.mod h1:pxXPTn3joSm21Gbwsv0w9OSA2y1HFR9qXEeXQVeNoDQ=
 github.com/gabriel-vasile/mimetype v1.4.12 h1:e9hWvmLYvtp846tLHam2o++qitpguFiYCKbn0w9jyqw=

--- a/api/v1beta1/openstackbaremetalset_webhook.go
+++ b/api/v1beta1/openstackbaremetalset_webhook.go
@@ -35,7 +35,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	goClient "sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
@@ -51,8 +50,6 @@ func SetupWebhookClient(client goClient.Client) {
 
 // log is for logging in this package.
 var openstackbaremetalsetlog = logf.Log.WithName("openstackbaremetalset-resource")
-
-var _ webhook.Validator = &OpenStackBaremetalSet{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *OpenStackBaremetalSet) ValidateCreate() (admission.Warnings, error) {

--- a/api/v1beta1/openstackprovisionserver_webhook.go
+++ b/api/v1beta1/openstackprovisionserver_webhook.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
@@ -44,8 +43,6 @@ func SetupOpenStackProvisionServerDefaults(defaults OpenStackProvisionServerDefa
 	openstackProvisionServerDefaults = defaults
 	openstackprovisionserverlog.Info("OpenStackProvisionServer defaults initialized", "defaults", defaults)
 }
-
-var _ webhook.Validator = &OpenStackProvisionServer{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *OpenStackProvisionServer) ValidateCreate() (admission.Warnings, error) {
@@ -97,8 +94,6 @@ func (r *OpenStackProvisionServer) ValidateDelete() (admission.Warnings, error) 
 
 	return nil, nil
 }
-
-var _ webhook.Defaulter = &OpenStackProvisionServer{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *OpenStackProvisionServer) Default() {


### PR DESCRIPTION
These compile-time assertions reference webhook.Defaulter and webhook.Validator interfaces that are removed in controller-runtime v0.21 (OCP 4.20). The assertions are dead code — webhook registration already uses CustomDefaulter/CustomValidator in internal/webhook/.

Removing them makes the API module forward-compatible with CR v0.21 so that consumers (like openstack-operator) can bump controller-runtime without needing replace directives for this operator.

Jira: [OSPRH-32989](https://redhat.atlassian.net/browse/OSPRH-32989)