### PR TITLE
Remove unnecessary pods RBAC permissions

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -9,7 +9,6 @@ rules:
   resources:
   - configmaps
   - configmaps/finalizers
-  - pods
   - secrets
   - secrets/finalizers
   - volumes
@@ -25,6 +24,7 @@ rules:
   - ""
   resources:
   - nodes
+  - pods
   verbs:
   - get
   - list

--- a/internal/controller/openstackprovisionserver_controller.go
+++ b/internal/controller/openstackprovisionserver_controller.go
@@ -82,7 +82,6 @@ type OpenStackProvisionServerReconciler struct {
 // +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=rolebindings,verbs=get;list;watch;create;update;patch
 // service account permissions that are needed to grant permission to the above
 // +kubebuilder:rbac:groups="security.openshift.io",resourceNames=hostnetwork,resources=securitycontextconstraints,verbs=use
-// +kubebuilder:rbac:groups="",resources=pods,verbs=create;delete;get;list;patch;update;watch
 
 // +kubebuilder:rbac:groups=baremetal.openstack.org,resources=openstackprovisionservers,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=baremetal.openstack.org,resources=openstackprovisionservers/status,verbs=get;list;update;patch
@@ -246,11 +245,6 @@ func (r *OpenStackProvisionServerReconciler) Reconcile(ctx context.Context, req 
 			ResourceNames: []string{"hostnetwork"},
 			Resources:     []string{"securitycontextconstraints"},
 			Verbs:         []string{"use"},
-		},
-		{
-			APIGroups: []string{""},
-			Resources: []string{"pods"},
-			Verbs:     []string{"create", "get", "list", "watch", "update", "patch", "delete"},
 		},
 		{
 			APIGroups: []string{"baremetal.openstack.org"},


### PR DESCRIPTION
The workload rbacRules and a kubebuilder RBAC marker granted full CRUD (create/delete/get/list/patch/update/watch) on core Pods, which was never exercised. Remove the unused permission and regenerate config/rbac/role.yaml.

The narrower get;list;update;watch;patch marker is kept, since the controller lists and updates provision server Pods directly.